### PR TITLE
pbsv_v2.6.0

### DIFF
--- a/reference.yaml
+++ b/reference.yaml
@@ -17,7 +17,7 @@ ref:
   hprc_dv_gnotate: 'resources/slivar/hprc.deepvariant.glnexus.hg38.v1.zip'
   eee_vcf: 'resources/eee/EEE_SV-Pop_1.ALL.sites.20181204.vcf.gz'
   gnomadsv_vcf: 'resources/gnomadsv/nstd166.GRCh38.variant_call.vcf.gz'
-  hprc_pbsv_vcf: 'resources/hprc/hprc.GRCh38.pbsv.vcf.gz'
+  hprc_pbsv_vcf: 'resources/hprc/hprc.GRCh38.pbsv.v.2.6.0-20210417.vcf.gz'
   autosomes: ['chr1', 'chr2', 'chr3', 'chr4', 'chr5',
               'chr6', 'chr7', 'chr8', 'chr9', 'chr10',
               'chr11', 'chr12', 'chr13', 'chr14', 'chr15',

--- a/rules/cohort_pbsv.smk
+++ b/rules/cohort_pbsv.smk
@@ -12,7 +12,7 @@ rule pbsv_call:
     benchmark: f"cohorts/{cohort}/benchmarks/pbsv/call/{cohort}.{ref}.{{region}}.tsv"
     params:
         region = lambda wildcards: wildcards.region,
-        extra = "--ccs -m 20 -A 3 -O 3 -P 20",
+        extra = "--ccs -m 20 -A 3 -O 3",
         loglevel = "INFO"
     threads: 8
     conda: "envs/pbsv.yaml"

--- a/rules/envs/pbsv.yaml
+++ b/rules/envs/pbsv.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pbsv ==2.4.0
+  - pbsv==2.6.0

--- a/rules/sample_pbsv.smk
+++ b/rules/sample_pbsv.smk
@@ -16,13 +16,15 @@ rule pbsv_discover:
     benchmark: f"samples/{sample}/benchmarks/pbsv/discover/{{movie}}.{ref}.{{region}}.tsv"
     params:
         region = lambda wildcards: wildcards.region,
-        loglevel = "INFO"
+        loglevel = "INFO",
+        min_gap_comp_id_perc = 97.0
     conda: "envs/pbsv.yaml"
     message: "Executing {rule}: Discovering structural variant signatures in {wildcards.region} from {input.bam}."
     shell:
         """
         (pbsv discover \
             --log-level {params.loglevel} \
+            --min-gap-comp-id-perc {params.min_gap_comp_id_perc} \
             --region {wildcards.region} \
             --tandem-repeats {input.tr_bed} \
             {input.bam} {output}) > {log} 2>&1
@@ -38,7 +40,7 @@ rule pbsv_call:
     benchmark: f"samples/{sample}/benchmarks/pbsv/call/{sample}.{ref}.{{region}}.tsv"
     params:
         region = lambda wildcards: wildcards.region,
-        extra = "--ccs -m 20 -A 3 -O 3 -P 20",
+        extra = "--ccs -m 20 -A 3 -O 3",
         loglevel = "INFO"
     threads: 8
     conda: "envs/pbsv.yaml"


### PR DESCRIPTION
update to use pbsv v2.6.0
- modify conda env to use new version
- revert to default read support option for `pbsv call`
- add minimum percent gap compressed identity filter parameter of 97% to `pbsv discover`