### PR TITLE
updated slivar to v0.2.2, improved handling of compound-hets

### DIFF
--- a/rules/envs/slivar.yaml
+++ b/rules/envs/slivar.yaml
@@ -2,6 +2,6 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - slivar==0.1.12
+  - slivar==0.2.2
   - bcftools==1.10
   - vcfpy==0.13.3


### PR DESCRIPTION
https://github.com/brentp/slivar/releases/tag/v0.2.2

solves the issues where `slivar compound-hets` returned no results and failed.