### PR TITLE
add-decode-sv-vcf

### DIFF
--- a/reference.yaml
+++ b/reference.yaml
@@ -18,6 +18,7 @@ ref:
   eee_vcf: 'resources/eee/EEE_SV-Pop_1.ALL.sites.20181204.vcf.gz'
   gnomadsv_vcf: 'resources/gnomadsv/nstd166.GRCh38.variant_call.vcf.gz'
   hprc_pbsv_vcf: 'resources/hprc/hprc.GRCh38.pbsv.v.2.6.0-20210417.vcf.gz'
+  decode_vcf: 'resources/decode/ont_sv_high_confidence_SVs.sorted.vcf.gz'
   autosomes: ['chr1', 'chr2', 'chr3', 'chr4', 'chr5',
               'chr6', 'chr7', 'chr8', 'chr9', 'chr10',
               'chr11', 'chr12', 'chr13', 'chr14', 'chr15',

--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -4,6 +4,7 @@ rule svpack_filter_annotated:
         eee_vcf = config['ref']['eee_vcf'],
         gnomadsv_vcf = config['ref']['gnomadsv_vcf'],
         hprc_pbsv_vcf = config['ref']['hprc_pbsv_vcf'],
+        decode_vcf = config['ref']['decode_vcf'],
         gff = config['ref']['ensembl_gff']
     output: f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.vcf"
     log: f"cohorts/{cohort}/logs/svpack/{cohort}.{ref}.pbsv.svpack.log"
@@ -18,6 +19,7 @@ rule svpack_filter_annotated:
             python workflow/scripts/svpack/svpack match -v - {input.eee_vcf} | \
             python workflow/scripts/svpack/svpack match -v - {input.gnomadsv_vcf} | \
             python workflow/scripts/svpack/svpack match -v - {input.hprc_pbsv_vcf} | \
+            python workflow/scripts/svpack/svpack match -v - {input.decode_vcf} | \
             python workflow/scripts/svpack/svpack consequence - {input.gff} | \
             python workflow/scripts/svpack/svpack tagzygosity - > {output}) 2> {log}
         """


### PR DESCRIPTION
- use decode vcf from Beyter, et al., Nat. Genetics, 2021 for svpack filtering of pbsv VCFs
- doi: 10.1038/s41588-021-00865-4
- https://github.com/DecodeGenetics/LRS_SV_sets