### PR TITLE
Update to hifiasm 0.15

### DIFF
--- a/process_sample.smk
+++ b/process_sample.smk
@@ -103,9 +103,9 @@ if 'kmers' in config['sample_targets']:
 include: 'rules/sample_hifiasm.smk'
 if 'assembly' in config['sample_targets']:
     # assembly and stats
-    targets.extend([f"samples/{sample}/hifiasm/{sample}.asm.{infix}.{suffix}"
+    targets.extend([f"samples/{sample}/hifiasm/{sample}.asm.bp.{infix}.{suffix}"
                 for suffix in ['fasta.gz', 'fasta.stats.txt']
-                for infix in ['a_ctg', 'p_ctg']])
+                for infix in ['hap1.p_ctg', 'hap2.p_ctg']])
     # assembly alignments
     targets.extend([f"samples/{sample}/hifiasm/{sample}.asm.{ref}.{suffix}"
                 for suffix in ['bam', 'bam.bai']])

--- a/rules/envs/hifiasm.yaml
+++ b/rules/envs/hifiasm.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - hifiasm==0.15
+  - hifiasm=0.15

--- a/rules/envs/hifiasm.yaml
+++ b/rules/envs/hifiasm.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - hifiasm==0.9
+  - hifiasm==0.15


### PR DESCRIPTION
- updated to hifiasm, which produces two unzipped assemblies (with phase switching) by default
- updated paths to new hifiasm name scheme