### PR TITLE
Improve slivar TSV headers

### DIFF
--- a/rules/cohort_slivar.smk
+++ b/rules/cohort_slivar.smk
@@ -181,8 +181,10 @@ rule slivar_tsv:
             --gene-description {input.clinvar_lookup} \
             --gene-description {input.phrank_lookup} \
             --ped {input.ped} \
-            --out {output.filt_tsv} \
-            {input.filt_vcf}
+            --out /dev/stdout \
+            {input.filt_vcf} \
+            | sed '1 s/gene_description_1/lof/;s/gene_description_2/clinvar/;s/gene_description_3/phrank/;' \
+            > {output.filt_tsv}
         slivar tsv \
             {params.info} \
             --sample-field slivar_comphet \
@@ -192,6 +194,8 @@ rule slivar_tsv:
             --gene-description {input.clinvar_lookup} \
             --gene-description {input.phrank_lookup} \
             --ped {input.ped} \
-            --out {output.comphet_tsv} \
-            {input.comphet_vcf}) > {log} 2>&1
+            --out /dev/stdout \
+            {input.comphet_vcf} \
+            | sed '1 s/gene_description_1/lof/;s/gene_description_2/clinvar/;s/gene_description_3/phrank/;' \
+            > {output.comphet_tsv}) > {log} 2>&1
         """

--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -60,6 +60,8 @@ rule slivar_svpack_tsv:
             --gene-description {input.clinvar_lookup} \
             --gene-description {input.phrank_lookup} \
             --ped {input.ped} \
-            --out {output.filt_tsv} \
-            {input.filt_vcf}) > {log} 2>&1
+            --out /dev/stdout \
+            {input.filt_vcf} \
+            | sed '1 s/gene_description_1/lof/;s/gene_description_2/clinvar/;s/gene_description_3/phrank/;' \
+            > {output.filt_tsv}) > {log} 2>&1
         """

--- a/rules/envs/slivar.yaml
+++ b/rules/envs/slivar.yaml
@@ -6,3 +6,4 @@ dependencies:
   - bcftools==1.10
   - vcfpy==0.13.3
   - python=3
+  - sed


### PR DESCRIPTION
Replaced the generic header names for the three `--gene-description` lookups in `slivar tsv` to use more descriptive names.

gene_description_1 -> lof
gene_description_2 -> clinvar
gene_description_3 -> phrank

Added `sed` (without version number) to `rules/env/slivar.yaml` to ensure that it would be available in the environment.

This hasn't been tested yet.
- does conda `sed` behave as expected?
- does the regex only replace the first line as expected?
- does `slivar tsv` write to `/dev/stdout`?