### PR TITLE
add missing bedtools.yaml

### DIFF
--- a/rules/envs/bedtools.yaml
+++ b/rules/envs/bedtools.yaml
@@ -1,0 +1,6 @@
+channels:
+  - bioconda
+  - anaconda
+dependencies:
+  - python=3
+  - bedtools==2.27.1


### PR DESCRIPTION
Environment was missing, but we never uncovered it because we were always directly supplying the file.