### PR TITLE
Discard_unnecessary_assembly_products

### DIFF
--- a/rules/sample_hifiasm.smk
+++ b/rules/sample_hifiasm.smk
@@ -30,7 +30,13 @@ rule hifiasm_assemble:
         f"samples/{sample}/hifiasm/{sample}.asm.bp.hap1.p_ctg.noseq.gfa",
         temp(f"samples/{sample}/hifiasm/{sample}.asm.bp.hap2.p_ctg.gfa"),
         f"samples/{sample}/hifiasm/{sample}.asm.bp.hap2.p_ctg.lowQ.bed",
-        f"samples/{sample}/hifiasm/{sample}.asm.bp.hap2.p_ctg.noseq.gfa"
+        f"samples/{sample}/hifiasm/{sample}.asm.bp.hap2.p_ctg.noseq.gfa",
+        temp(f"samples/{sample}/hifiasm/{sample}.asm.bp.p_ctg.gfa"),
+        temp(f"samples/{sample}/hifiasm/{sample}.asm.bp.p_utg.gfa"),
+        temp(f"samples/{sample}/hifiasm/{sample}.asm.bp.r_utg.gfa"),
+        temp(f"samples/{sample}/hifiasm/{sample}.asm.ec.bin"),
+        temp(f"samples/{sample}/hifiasm/{sample}.asm.ovlp.reverse.bin"),
+        temp(f"samples/{sample}/hifiasm/{sample}.asm.ovlp.source.bin")
     log: f"samples/{sample}/logs/hifiasm.log"
     benchmark: f"samples/{sample}/benchmarks/hifiasm.tsv"
     conda: "envs/hifiasm.yaml"


### PR DESCRIPTION
Currently keeping the hifiasm `*.bin` files and `{p_ctg,p_utg,r_utg}.gfa` files, which take up a lot of space.  Added `temp()` wrappers to clean these up.