### PR TITLE
Detecting runs of homozygosity

### DIFF
--- a/process_sample.smk
+++ b/process_sample.smk
@@ -61,7 +61,7 @@ if 'deepvariant' in config['sample_targets']:
     # deepvariant VCFs, gVCFs, reports, and stats
     targets.extend([f"samples/{sample}/deepvariant/{sample}.{ref}.deepvariant.{suffix}"
                     for suffix in ['vcf.gz', 'vcf.gz.tbi', 'g.vcf.gz', 'g.vcf.gz.tbi',
-                                'visual_report.html', 'vcf.stats.txt']])
+                                   'visual_report.html', 'vcf.stats.txt', 'roh.bed']])
 
 # phase small variants with WhatsHap and haplotag BAM
 include: 'rules/sample_whatshap.smk'

--- a/rules/sample_deepvariant.smk
+++ b/rules/sample_deepvariant.smk
@@ -179,7 +179,7 @@ rule deepvariant_bcftools_roh:
     message: "Executing {rule}: Calculating runs of homozygosity for {input}."
     shell:
         """
-        (echo -e "chr\tstart\tend\tqual\n" > {output}
+        (echo -e "chr\tstart\tend\tqual" > {output}
         bcftools roh --AF-dflt {params.default_allele_frequency} {input} \
         | awk -v OFS='\t' '$1=="RG" {{ print $3, $4, $5, $8 }} |
         >> {output}) > {log} 2>&1

--- a/rules/sample_deepvariant.smk
+++ b/rules/sample_deepvariant.smk
@@ -169,4 +169,21 @@ rule deepvariant_bcftools_stats:
     shell: "(bcftools stats --threads 3 {params} {input} > {output}) > {log} 2>&1"
 
 
+rule deepvariant_bcftools_roh:
+    input: f"samples/{sample}/deepvariant/{sample}.{ref}.deepvariant.vcf.gz"
+    output: f"samples/{sample}/deepvariant/{sample}.{ref}.deepvariant.roh.bed"
+    log: f"samples/{sample}/logs/bcftools/stats/{sample}.{ref}.deepvariant.vcf.log"
+    benchmark: f"samples/{sample}/benchmarks/bcftools/stats/{sample}.{ref}.deepvariant.vcf.tsv"
+    params: default_allele_frequency = 0.4
+    conda: "envs/bcftools.yaml"
+    message: "Executing {rule}: Calculating runs of homozygosity for {input}."
+    shell:
+        """
+        (echo -e "chr\tstart\tend\tqual\n" > {output}
+        bcftools roh --AF-dflt {params.default_allele_frequency} {input} \
+        | awk -v OFS='\t' '$1=="RG" {{ print $3, $4, $5, $8 }} |
+        >> {output}) > {log} 2>&1
+        """
+
+
 # TODO: cleanup deepvariant intermediates

--- a/rules/sample_deepvariant.smk
+++ b/rules/sample_deepvariant.smk
@@ -179,9 +179,9 @@ rule deepvariant_bcftools_roh:
     message: "Executing {rule}: Calculating runs of homozygosity for {input}."
     shell:
         """
-        (echo -e "chr\tstart\tend\tqual" > {output}
+        (echo -e "#chr\tstart\tend\tqual" > {output}
         bcftools roh --AF-dflt {params.default_allele_frequency} {input} \
-        | awk -v OFS='\t' '$1=="RG" {{ print $3, $4, $5, $8 }} |
+        | awk -v OFS='\t' '$1=="RG" {{ print $3, $4, $5, $8 }}' \
         >> {output}) > {log} 2>&1
         """
 


### PR DESCRIPTION
- detect roh with `bcftools roh`
- transform output into a BED with header