### PR TITLE
Fix SV inheritance logic without slivar

### DIFF
--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -25,6 +25,26 @@ rule svpack_filter_annotated:
         """
 
 
+rule check_sv_inheritance_pattern:
+    input: f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.vcf"
+    output: f"cohorts/{cohort}/svpack/{cohort}.{ref}.pbsv.svpack.filtered_inheritance.vcf"
+    log: f"cohorts/{cohort}/logs/svpack/{cohort}.{ref}.pbsv.svpack.filtered_inheritance.log"
+    benchmark: f"cohorts/{cohort}/benchmarks/svpack/{cohort}.{ref}.pbsv.svpack.filtered_inheritance.tsv"
+    params:
+        min_depth = 5,
+        affecteds = affecteds,
+        unaffecteds = unaffecteds,
+    conda: "envs/svpack.yaml"
+    shell:
+        """
+        (python workflow/scripts/sv_inheritance.py \
+            --min_depth {params.min_depth} \
+            --affecteds {params.affecteds} \
+            --unaffecteds {params.unaffecteds} \
+            {input} > {output}) 2> {log}
+        """
+
+
 info_fields = [
     'SVTYPE',
     'SVLEN',

--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -41,7 +41,7 @@ rule check_sv_inheritance_pattern:
             --min_depth {params.min_depth} \
             --affecteds {params.affecteds} \
             --unaffecteds {params.unaffecteds} \
-            {input} > {output}) 2> {log}
+            {input} {output}) 2> {log}
         """
 
 

--- a/scripts/sv_inheritance.py
+++ b/scripts/sv_inheritance.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+This script takes a vcf file and filters variants that are less likely to be causal
+based on the inheritance.
+"""
+
+__author__ = "William Rowell"
+__version__ = "0.1.0"
+
+
+import sys
+import argparse
+from pysam import VariantFile
+
+
+def unaffected_homalt(homalts, unaffecteds):
+    "if unaff is homalt, variant is not causal"
+    return homalts.intersection(unaffecteds)
+
+
+def affected_homref_or_unknown(alts, affecteds):
+    "if aff is homref or unk, variant is not causal"
+    return alts.intersection(affecteds) != affecteds
+
+
+def unaffected_hetalt_affected_hetalt(homalts, hetalts, unaffecteds, affecteds):
+    "if unaff is hetalt, variant is causal only if aff is homalt"
+    return (
+        hetalts.intersection(unaffecteds)
+        and homalts.intersection(affecteds) != affecteds
+    )
+
+
+def below_min_depth(record, min_depth):
+    "check if any samples are below minimum depth"
+    return any([record.samples[_]["DP"] < min_depth for _ in record.samples.keys()])
+
+
+def main(arguments):
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("vcf_in", help="input vcf", type=str)
+    parser.add_argument("vcf_out", help="output vcf", type=str)
+    parser.add_argument("--affecteds", help="reference contig", type=str, default="")
+    parser.add_argument("--unaffecteds", help="reference contig", type=str, default="")
+    parser.add_argument("--min_depth", help="minimum GT/DP", type=int, default=0)
+    args = parser.parse_args(arguments)
+
+    affecteds = set(args.affecteds.split(",")) if args.affecteds else set()
+    unaffecteds = set(args.unaffecteds.split(",")) if args.unaffecteds else set()
+
+    with VariantFile(args.vcf_in) as reader, VariantFile(
+        args.vcf_out, "w", header=reader.header
+    ) as writer:
+        for record in reader:
+            homalts = set(record.info["homalt"]) if "homalt" in record.info else set()
+            hetalts = set(record.info["hetalt"]) if "hetalt" in record.info else set()
+            alts = homalts.union(hetalts)
+
+            if unaffected_homalt(homalts, unaffecteds):
+                continue
+            if affected_homref_or_unknown(alts, affecteds):
+                continue
+            if unaffected_hetalt_affected_hetalt(
+                homalts, hetalts, unaffecteds, affecteds
+            ):
+                continue
+            if below_min_depth(record, args.min_depth):
+                continue
+            writer.write(record)
+
+
+if __name__ == "__main__":
+    """This is executed when run from the command line"""
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
This is a first stab at adding the missing logic to filter SVs that don't fit expected inheritance patterns (re: #4).  The python script is tested, but integration is untested.

The script filters out:
- records where an unaffected is homalt
- records where not all affecteds are alt
- records where an unaffected is hetalt and not all of the affecteds are homalt
- records where any sample depth is below a minimum cutoff

1) What should the default minimum depth be?
2) Are any of the filters too strict?
3) Should we be annotating instead of filtering?
4) What do we do with this output?  Is this the output that will be used to generate the TSV?

Other thoughts?