### PR TITLE
updated DeepVariant to v1.3.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,8 +28,8 @@ tmpdir: '/tmp'
 kmer_length: 21
 
 # deepvariant
-#DEEPVARIANT_VERSION: '1.2.0'  # CPU-only, will require modifying threads for call_variants rules
-DEEPVARIANT_VERSION: '1.2.0-gpu'  # GPU
+#DEEPVARIANT_VERSION: '1.3.0'  # CPU-only, will require modifying threads for call_variants rules
+DEEPVARIANT_VERSION: '1.3.0-gpu'  # GPU
 N_SHARDS: 256
 
 # glnexus


### PR DESCRIPTION
Incremented version of DeepVariant docker image to newest release.

https://github.com/google/deepvariant/releases/tag/v1.3.0