### PR TITLE
Update pbsv from v2.6.0 to v2.8

### DIFF
--- a/rules/cohort_pbsv.smk
+++ b/rules/cohort_pbsv.smk
@@ -12,7 +12,7 @@ rule pbsv_call:
     benchmark: f"cohorts/{cohort}/benchmarks/pbsv/call/{cohort}.{ref}.{{region}}.tsv"
     params:
         region = lambda wildcards: wildcards.region,
-        extra = "--ccs -m 20 -A 3 -O 3",
+        extra = "--hifi -m 20",
         loglevel = "INFO"
     threads: 8
     conda: "envs/pbsv.yaml"

--- a/rules/envs/pbsv.yaml
+++ b/rules/envs/pbsv.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pbsv==2.6.0
+  - pbsv=2.8

--- a/rules/sample_pbsv.smk
+++ b/rules/sample_pbsv.smk
@@ -15,16 +15,15 @@ rule pbsv_discover:
     log: f"samples/{sample}/logs/pbsv/discover/{{movie}}.{ref}.{{region}}.log"
     benchmark: f"samples/{sample}/benchmarks/pbsv/discover/{{movie}}.{ref}.{{region}}.tsv"
     params:
+        extra = "--hifi",
         region = lambda wildcards: wildcards.region,
-        loglevel = "INFO",
-        min_gap_comp_id_perc = 97.0
+        loglevel = "INFO"
     conda: "envs/pbsv.yaml"
     message: "Executing {rule}: Discovering structural variant signatures in {wildcards.region} from {input.bam}."
     shell:
         """
-        (pbsv discover \
+        (pbsv discover {params.extra} \
             --log-level {params.loglevel} \
-            --min-gap-comp-id-perc {params.min_gap_comp_id_perc} \
             --region {wildcards.region} \
             --tandem-repeats {input.tr_bed} \
             {input.bam} {output}) > {log} 2>&1
@@ -40,7 +39,7 @@ rule pbsv_call:
     benchmark: f"samples/{sample}/benchmarks/pbsv/call/{sample}.{ref}.{{region}}.tsv"
     params:
         region = lambda wildcards: wildcards.region,
-        extra = "--ccs -m 20 -A 3 -O 3",
+        extra = "--hifi -m 20",
         loglevel = "INFO"
     threads: 8
     conda: "envs/pbsv.yaml"


### PR DESCRIPTION
- pinned to 2.8 to allow for patches
- `pbsv discover -y 97` is now included in new `pbsv discver --hifi` preset
- `pbsv call -A 3 -O 3` is now default behavior
- `pbsv call --ccs` changed to equivalent `pbsv call --hifi` for consistency