### PR TITLE
pileup width changed for DeepVariant v1.3.0

### DIFF
--- a/rules/sample_deepvariant.smk
+++ b/rules/sample_deepvariant.smk
@@ -13,6 +13,7 @@ rule deepvariant_make_examples_round1:
     container: f"docker://google/deepvariant:{config['DEEPVARIANT_VERSION']}"
     params:
         vsc_min_fraction_indels = "0.12",
+        pileup_image_width = 199,
         shard = lambda wildcards: wildcards.shard,
         reads = ','.join(abams)
     message: "Executing {rule}: DeepVariant make_examples {wildcards.shard} for {input.bams}."
@@ -21,6 +22,7 @@ rule deepvariant_make_examples_round1:
         (/opt/deepvariant/bin/make_examples \
             --norealign_reads \
             --vsc_min_fraction_indels {{params.vsc_min_fraction_indels}} \
+            --pileup_image_width {{params.pileup_image_width}} \
             --alt_aligned_pileup=diff_channels \
             --add_hp_channel \
             --sort_by_haplotypes \
@@ -89,6 +91,7 @@ rule deepvariant_make_examples_round2:
     container: f"docker://google/deepvariant:{config['DEEPVARIANT_VERSION']}"
     params:
         vsc_min_fraction_indels = "0.12",
+        pileup_image_width = 199,
         shard = lambda wildcards: wildcards.shard,
         reads = ','.join(haplotagged_abams)
     message: "Executing {rule}: DeepVariant make_examples {wildcards.shard} for {input.bams}."
@@ -97,6 +100,7 @@ rule deepvariant_make_examples_round2:
         (/opt/deepvariant/bin/make_examples \
             --norealign_reads \
             --vsc_min_fraction_indels {{params.vsc_min_fraction_indels}} \
+            --pileup_image_width {{params.pileup_image_width}} \
             --alt_aligned_pileup=diff_channels \
             --add_hp_channel \
             --sort_by_haplotypes \


### PR DESCRIPTION
DeepVariant v1.3.0 added a new special argument for `make_examples` when running PacBio models.  The pileup window has changed from 221bp to 199bp.