### PR TITLE
moved many tasks to localrules

### DIFF
--- a/process_sample.smk
+++ b/process_sample.smk
@@ -114,7 +114,7 @@ if 'assembly' in config['sample_targets']:
                     for suffix in ['vcf.gz', 'vcf.gz.tbi', 'vcf.stats.txt']])
 
 
-localrules: all
+localrules: all, md5sum
 
 
 rule all:

--- a/process_smrtcells.sh
+++ b/process_smrtcells.sh
@@ -3,7 +3,7 @@
 #SBATCH -p compute
 #SBATCH -N 1
 #SBATCH -n 1
-#SBATCH --cpus-per-task 1
+#SBATCH --cpus-per-task 4
 #SBATCH -o cluster_logs/slurm-%x-%j-%N.out
 
 # set umask to avoid locking each other out of directories
@@ -13,7 +13,7 @@ umask 002
 snakemake --reason \
     --rerun-incomplete \
     --keep-going \
-    --local-cores 1 \
+    --local-cores 4 \
     --jobs 500 \
     --max-jobs-per-second 1 \
     --use-conda --conda-frontend mamba \

--- a/process_smrtcells.smk
+++ b/process_smrtcells.smk
@@ -105,7 +105,7 @@ if 'kmers' in config['smrtcells_targets']:
                     for movie in list(fastq_dict[sample].keys())]) # kmers from FASTQs
 
 
-localrules: all
+localrules: all, md5sum
 
 
 rule all:

--- a/rules/cohort_common.smk
+++ b/rules/cohort_common.smk
@@ -1,4 +1,4 @@
-localrules: bgzip_vcf, tabix_vcf, tabix_bcf, create_ped
+localrules: bgzip_vcf, tabix_vcf, tabix_bcf, create_ped, calculate_phrank
 
 
 rule bgzip_vcf:

--- a/rules/cohort_glnexus.smk
+++ b/rules/cohort_glnexus.smk
@@ -1,4 +1,5 @@
-# gvcf_list -> list of g.vcf.gz for all samples
+localrules: whatshap_bcftools_concat
+
 
 rule glnexus:
     input:

--- a/rules/cohort_hifiasm.smk
+++ b/rules/cohort_hifiasm.smk
@@ -1,4 +1,5 @@
 ruleorder: samtools_fasta > seqtk_fastq_to_fasta
+localrules: asm_stats
 
 
 rule samtools_fasta:

--- a/rules/cohort_hifiasm.smk
+++ b/rules/cohort_hifiasm.smk
@@ -1,5 +1,5 @@
 ruleorder: samtools_fasta > seqtk_fastq_to_fasta
-localrules: asm_stats
+localrules: asm_stats, gfa2fa
 
 
 rule samtools_fasta:

--- a/rules/cohort_pbsv.smk
+++ b/rules/cohort_pbsv.smk
@@ -1,5 +1,3 @@
-# svsig_dict[chrom] = list of svsigs for all movies for all samples for given chrom
-
 localrules: bcftools_concat_pbsv_vcf
 
 

--- a/rules/cohort_slivar.smk
+++ b/rules/cohort_slivar.smk
@@ -1,4 +1,4 @@
-localrules: reformat_ensembl_gff, generate_lof_lookup, generate_clinvar_lookup
+localrules: reformat_ensembl_gff, generate_lof_lookup, generate_clinvar_lookup, slivar_tsv
 
 
 rule reformat_ensembl_gff:

--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -1,3 +1,6 @@
+localrules: slivar_svpack_tsv
+
+
 rule svpack_filter_annotated:
     input:
         pbsv_vcf = svpack_input,

--- a/rules/sample_deepvariant.smk
+++ b/rules/sample_deepvariant.smk
@@ -1,3 +1,6 @@
+localrules: deepvariant_bcftools_stats, deepvariant_bcftools_roh
+
+
 shards = [f"{x:05}" for x in range(config['N_SHARDS'])]
 
 

--- a/rules/sample_gc_coverage.smk
+++ b/rules/sample_gc_coverage.smk
@@ -1,5 +1,6 @@
 localrules: calculate_sample_gc_coverage
 
+
 rule calculate_sample_gc_coverage:
     input:
         mosdepth_regions = f"samples/{{sample}}/mosdepth/{{sample}}.{ref}.deepvariant.haplotagged.regions.bed.gz",

--- a/rules/sample_hifiasm.smk
+++ b/rules/sample_hifiasm.smk
@@ -1,4 +1,5 @@
 ruleorder: samtools_fasta > seqtk_fastq_to_fasta
+localrules: asm_stats, htsbox_bcftools_stats
 
 
 rule samtools_fasta:
@@ -132,4 +133,3 @@ rule htsbox_bcftools_stats:
     conda: "envs/bcftools.yaml"
     message: "Executing {rule}: Calculating VCF statistics for {input}."
     shell: "(bcftools stats --threads 3 {params} {input} > {output}) > {log} 2>&1"
-

--- a/rules/sample_hifiasm.smk
+++ b/rules/sample_hifiasm.smk
@@ -1,5 +1,5 @@
 ruleorder: samtools_fasta > seqtk_fastq_to_fasta
-localrules: asm_stats, htsbox_bcftools_stats
+localrules: asm_stats, htsbox_bcftools_stats, gfa2fa
 
 
 rule samtools_fasta:

--- a/rules/sample_tandem_genotypes.smk
+++ b/rules/sample_tandem_genotypes.smk
@@ -1,3 +1,6 @@
+localrules: download_tg_list, generate_tg_bed, tandem_genotypes_absolute_count, tandem_genotypes_plot, tandem_repeat_coverage_dropouts
+
+
 rule download_tg_list:
     output: config['ref']['tg_list']
     log: "logs/download_tg_list.log"

--- a/rules/smrtcell_stats.smk
+++ b/rules/smrtcell_stats.smk
@@ -1,4 +1,5 @@
 ruleorder: smrtcell_stats_ubam > smrtcell_stats_fastq
+localrules: smrtcell_summary_stats
 
 
 rule smrtcell_stats_ubam:


### PR DESCRIPTION
Moved many of the single-threaded non-scatter tasks to localrules
to make better use of resources.