### PR TITLE
Set memory for GLnexus

### DIFF
--- a/rules/cohort_glnexus.smk
+++ b/rules/cohort_glnexus.smk
@@ -16,7 +16,7 @@ rule glnexus:
     shell:
         """
         (rm -rf {output.scratch_dir} && \
-        glnexus_cli --threads {threads} \
+        glnexus_cli --threads {threads} --mem-gbytes 192 \
             --dir {output.scratch_dir} \
             --config DeepVariant_unfiltered {input.gvcf} > {output.bcf}) 2> {log}
         """

--- a/rules/cohort_glnexus.smk
+++ b/rules/cohort_glnexus.smk
@@ -10,13 +10,15 @@ rule glnexus:
         scratch_dir = temp(directory(f"cohorts/{cohort}/glnexus/{cohort}.{ref}.GLnexus.DB/"))
     log: f"cohorts/{cohort}/logs/glnexus/{cohort}.{ref}.log"
     benchmark: f"cohorts/{cohort}/benchmarks/glnexus/{cohort}.{ref}.tsv"
+    params:
+        mem_gbytes = 192,
     container: f"docker://ghcr.io/dnanexus-rnd/glnexus:{config['GLNEXUS_VERSION']}"
     threads: 24
     message: f"Executing {{rule}}: Joint calling variants from {cohort} cohort."
     shell:
         """
         (rm -rf {output.scratch_dir} && \
-        glnexus_cli --threads {threads} --mem-gbytes 192 \
+        glnexus_cli --threads {threads} --mem-gbytes {params.mem_gbytes} \
             --dir {output.scratch_dir} \
             --config DeepVariant_unfiltered {input.gvcf} > {output.bcf}) 2> {log}
         """


### PR DESCRIPTION
By default, GLnexus will expand to use all available memory.
This can result in slurm resource conflicts.

- Set memory for GLnexus to 192G (threads*8G)