### PR TITLE
don't merge if there's only one input haplotagged aBAM

### DIFF
--- a/rules/sample_whatshap.smk
+++ b/rules/sample_whatshap.smk
@@ -172,12 +172,12 @@ rule merge_haplotagged_bams:
     conda: "envs/samtools.yaml"
     message: "Executing {rule}: Merging {input}."
     shell:
-        f"""
-        if [[ "{{input}}" =~ " " ]]
+        """
+        if [[ "{input}" =~ " " ]]
         then
             (samtools merge -@ 7 {output} {input}) > {log} 2>&1
         else
-            mv {{input}} {{output}}
+            mv {input} {output}
         fi
         """
 

--- a/rules/sample_whatshap.smk
+++ b/rules/sample_whatshap.smk
@@ -171,7 +171,14 @@ rule merge_haplotagged_bams:
     threads: 8
     conda: "envs/samtools.yaml"
     message: "Executing {rule}: Merging {input}."
-    shell: "(samtools merge -@ 7 {output} {input}) > {log} 2>&1"
-
+    shell:
+        f"""
+        if [[ "{{input}}" =~ " " ]]
+        then
+            (samtools merge -@ 7 {output} {input}) > {log} 2>&1
+        else
+            mv {{input}} {{output}}
+        fi
+        """
 
 # TODO: cleanup whatshap intermediates


### PR DESCRIPTION
`mv` has to be faster than `samtools view`.