### PR TITLE
Feature: expose pbsv params in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,10 @@ tmpdir: '/tmp'
 # jellyfish and genomescope
 kmer_length: 21
 
+# pbsv
+# pass along extra parameters to pbsv that will override the hifi defaults
+pbsv_call_extra: ""
+
 # deepvariant
 #DEEPVARIANT_VERSION: '1.3.0'  # CPU-only, will require modifying threads for call_variants rules
 DEEPVARIANT_VERSION: '1.3.0-gpu'  # GPU

--- a/rules/cohort_pbsv.smk
+++ b/rules/cohort_pbsv.smk
@@ -10,7 +10,7 @@ rule pbsv_call:
     benchmark: f"cohorts/{cohort}/benchmarks/pbsv/call/{cohort}.{ref}.{{region}}.tsv"
     params:
         region = lambda wildcards: wildcards.region,
-        extra = "--hifi -m 20",
+        extra = "--hifi -m 20 " + config['pbsv_call_extra'],
         loglevel = "INFO"
     threads: 8
     conda: "envs/pbsv.yaml"

--- a/rules/sample_pbsv.smk
+++ b/rules/sample_pbsv.smk
@@ -39,7 +39,7 @@ rule pbsv_call:
     benchmark: f"samples/{sample}/benchmarks/pbsv/call/{sample}.{ref}.{{region}}.tsv"
     params:
         region = lambda wildcards: wildcards.region,
-        extra = "--hifi -m 20",
+        extra = "--hifi -m 20 " + config['pbsv_call_extra'],
         loglevel = "INFO"
     threads: 8
     conda: "envs/pbsv.yaml"


### PR DESCRIPTION
If the user intends to use less coverage than recommended, they can modify the pbsv parameters via `config.yaml`.