### PR TITLE
Feature/bug: Use less complex comphet logic for multi-sample cohorts

### DIFF
--- a/rules/cohort_slivar.smk
+++ b/rules/cohort_slivar.smk
@@ -63,13 +63,8 @@ slivar_filters = [
                        && fam.every(segregating_dominant_x) \
                        && INFO.gnomad_ac <= {config['max_gnomad_ac']} \
                        && INFO.hprc_ac <= {config['max_hprc_ac']}'""",
+        f"--sample-expr 'comphet_side:sample.het && sample.GQ > {config['min_gq']}'",
 ]
-if singleton:
-    # singleton
-    slivar_filters.append(f"--sample-expr 'comphet_side:sample.het && sample.GQ > {config['min_gq']}'")
-else:
-    # trio cohort
-    slivar_filters.append("--trio 'comphet_side:comphet_side(kid, mom, dad) && kid.affected'")
 
 
 rule slivar_small_variant:


### PR DESCRIPTION
Previous behavior:
- for singletons, consider all het variants as potential compound hets
- for multi-sample cohorts, use the trio function `comphet_side()` from slivar-functions.js

In trios, the multi-sample cohort behavior was great.  It resulted in many fewer variants to sift through.  For multi-sample non-trio cohorts, the behavior wasn't great, especially if we don't have the relationships described in a PED file.

New behavior:
- for all cohorts, consider all het variants as potential compound hets

We'll have more proposed compound het combinations, but we can filter these out downstream.

Thoughts?