### PR TITLE
Feature: align assembly without chunking contigs

### DIFF
--- a/rules/cohort_hifiasm.smk
+++ b/rules/cohort_hifiasm.smk
@@ -115,26 +115,18 @@ rule align_hifiasm:
     log: f"cohorts/{cohort}/logs/align_hifiasm/{{sample}}.asm.{ref}.log"
     benchmark: f"cohorts/{cohort}/benchmarks/align_hifiasm/{{sample}}.asm.{ref}.tsv"
     params:
-        max_chunk = 200000,
         minimap2_args = "-L --secondary=no --eqx -ax asm5",
-        minimap2_threads = 10,
+        minimap2_threads = 12,
         readgroup = f"@RG\\tID:{{sample}}_hifiasm\\tSM:{{sample}}",
         samtools_threads = 3,
         samtools_mem = "8G"
-    threads: 16  # minimap2 + samtools(+1) + 2x awk + seqtk + cat
+    threads: 16  # minimap2 + samtools(+3)
     conda: "envs/align_hifiasm.yaml"
     message: "Executing {rule}: Aligning {input.query} to {input.target}."
     shell:
         """
-        (cat {input.query} \
-            | seqtk seq -l {params.max_chunk} - \
-            | awk '{{ if ($1 ~ />/) {{ n=$1; i=0; }} else {{ i++; print n "." i; print $0; }} }}' \
-            | minimap2 -t {params.minimap2_threads} {params.minimap2_args} \
-                -R '{params.readgroup}' {input.target} - \
-                | awk '{{ if ($1 !~ /^@/) \
-                                {{ Rct=split($1,R,"."); N=R[1]; for(i=2;i<Rct;i++) {{ N=N"."R[i]; }} print $0 "\tTG:Z:" N; }} \
-                              else {{ print; }} }}' \
-                | samtools sort -@ {params.samtools_threads} -T $TMPDIR -m {params.samtools_mem} > {output}) > {log} 2>&1
+        (minimap2 -t {params.minimap2_threads} {params.minimap2_args} -R '{params.readgroup}' {input.target} {input.query} \
+            | samtools sort -@ {params.samtools_threads} -T $TMPDIR -m {params.samtools_mem} > {output}) > {log} 2>&1
         """
 
 

--- a/rules/envs/align_hifiasm.yaml
+++ b/rules/envs/align_hifiasm.yaml
@@ -4,5 +4,4 @@ channels:
   - defaults
 dependencies:
   - minimap2==2.17
-  - samtools==1.10
-  - seqtk==1.3
+  - samtools=1.14

--- a/rules/envs/bcftools.yaml
+++ b/rules/envs/bcftools.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bcftools==1.10
+  - bcftools=1.14

--- a/rules/envs/htslib.yaml
+++ b/rules/envs/htslib.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - htslib==1.10
+  - htslib=1.14

--- a/rules/envs/last.yaml
+++ b/rules/envs/last.yaml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - last==1186
   - htslib==1.10
-  - samtools==1.10
+  - samtools=1.14

--- a/rules/envs/samtools.yaml
+++ b/rules/envs/samtools.yaml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - samtools==1.10
+  - samtools=1.14

--- a/rules/sample_hifiasm.smk
+++ b/rules/sample_hifiasm.smk
@@ -87,26 +87,18 @@ rule align_hifiasm:
     log: f"samples/{sample}/logs/align_hifiasm/{sample}.asm.{ref}.log"
     benchmark: f"samples/{sample}/benchmarks/align_hifiasm/{sample}.asm.{ref}.tsv"
     params:
-        max_chunk = 200000,
         minimap2_args = "-L --secondary=no --eqx -ax asm5",
         minimap2_threads = 10,
         readgroup = f"@RG\\tID:{sample}_hifiasm\\tSM:{sample}",
         samtools_threads = 3,
         samtools_mem = "8G"
-    threads: 16  # minimap2 + samtools(+1) + 2x awk + seqtk + cat
+    threads: 16  # minimap2 + samtools(+3)
     conda: "envs/align_hifiasm.yaml"
     message: "Aligning {input.query} to {input.target}."
     shell:
         """
-        (cat {input.query} \
-            | seqtk seq -l {params.max_chunk} - \
-            | awk '{{ if ($1 ~ />/) {{ n=$1; i=0; }} else {{ i++; print n "." i; print $0; }} }}' \
-            | minimap2 -t {params.minimap2_threads} {params.minimap2_args} \
-                -R '{params.readgroup}' {input.target} - \
-                | awk '{{ if ($1 !~ /^@/) \
-                                {{ Rct=split($1,R,"."); N=R[1]; for(i=2;i<Rct;i++) {{ N=N"."R[i]; }} print $0 "\tTG:Z:" N; }} \
-                              else {{ print; }} }}' \
-                | samtools sort -@ {params.samtools_threads} -T $TMPDIR -m {params.samtools_mem} > {output}) > {log} 2>&1
+        (minimap2 -t {params.minimap2_threads} {params.minimap2_args} -R '{params.readgroup}' {input.target} {input.query} \
+            | samtools sort -@ {params.samtools_threads} -T $TMPDIR -m {params.samtools_mem} > {output}) > {log} 2>&1
         """
 
 

--- a/rules/sample_hifiasm.smk
+++ b/rules/sample_hifiasm.smk
@@ -88,7 +88,7 @@ rule align_hifiasm:
     benchmark: f"samples/{sample}/benchmarks/align_hifiasm/{sample}.asm.{ref}.tsv"
     params:
         minimap2_args = "-L --secondary=no --eqx -ax asm5",
-        minimap2_threads = 10,
+        minimap2_threads = 12,
         readgroup = f"@RG\\tID:{sample}_hifiasm\\tSM:{sample}",
         samtools_threads = 3,
         samtools_mem = "8G"


### PR DESCRIPTION
We previously broke assembly contigs into 200kb chunks during alignment for IGV viewing.  Let's evaluate whether this is still necessary.

In previous merges, we updated the memory per sort thread to 8G.  Here I update samtools to 1.14, which has worked for me locally.