### PR TITLE
singularity tmpdir and hifi reads regex

### DIFF
--- a/process_cohort.local.sh
+++ b/process_cohort.local.sh
@@ -22,7 +22,6 @@ snakemake --reason \
     --keep-going \
     --printshellcmds \
     --config cohort=${COHORT} \
-    --nolock \
     --cores 78 \
     --use-conda --conda-frontend mamba \
     --use-singularity \

--- a/process_cohort.local.sh
+++ b/process_cohort.local.sh
@@ -5,13 +5,17 @@ umask 002
 
 COHORT=$1
 mkdir -p cohorts/${COHORT}/
-LOCKFILE=cohorts/${COHORT}/process_cohort.lock
+# LOCKFILE=cohorts/${COHORT}/process_cohort.lock
 
 # add lockfile to directory to prevent multiple simultaneous jobs
-lockfile -r 0 ${LOCKFILE} || exit 1
-trap "rm -f ${LOCKFILE}; exit" SIGINT SIGTERM ERR EXIT
+# lockfile -r 0 ${LOCKFILE} || exit 1
+# trap "rm -f ${LOCKFILE}; exit" SIGINT SIGTERM ERR EXIT
 
 mkdir -p logs
+
+source workflow/variables.env
+export SINGULARITY_TMPDIR="$TEMP"
+export SINGULARITY_BIND="$TEMP"
 
 # execute snakemake
 snakemake --reason \
@@ -22,6 +26,6 @@ snakemake --reason \
     --cores 78 \
     --use-conda --conda-frontend mamba \
     --use-singularity \
-    --default-resources "tmpdir=system_tmpdir" \
+    --default-resources "tmpdir='${TEMP}'" \
     --snakefile workflow/process_cohort.smk \
     2>&1 | tee "logs/process_cohort.${COHORT}.$(date -d 'today' +'%Y%m%d%H%M').log"

--- a/process_sample.local.sh
+++ b/process_sample.local.sh
@@ -23,7 +23,6 @@ snakemake --reason \
     --cores 78 \
     --printshellcmds \
     --config sample=${SAMPLE} \
-    --nolock \
     --use-conda --conda-frontend mamba \
     --use-singularity \
     --default-resources "tmpdir='${TEMP}'" \

--- a/process_sample.local.sh
+++ b/process_sample.local.sh
@@ -4,13 +4,17 @@
 umask 002
 
 SAMPLE=$1
-LOCKFILE=samples/${SAMPLE}/process_sample.lock
+# LOCKFILE=samples/${SAMPLE}/process_sample.lock
 
 # add lockfile to directory to prevent multiple simultaneous jobs
-lockfile -r 0 ${LOCKFILE} || exit 1
-trap "rm -f ${LOCKFILE}; exit" SIGINT SIGTERM ERR EXIT
+# lockfile -r 0 ${LOCKFILE} || exit 1
+# trap "rm -f ${LOCKFILE}; exit" SIGINT SIGTERM ERR EXIT
 
 mkdir -p logs
+
+source workflow/variables.env
+export SINGULARITY_TMPDIR="$TEMP"
+export SINGULARITY_BIND="$TEMP"
 
 # execute snakemake
 snakemake --reason \
@@ -22,6 +26,6 @@ snakemake --reason \
     --nolock \
     --use-conda --conda-frontend mamba \
     --use-singularity \
-    --default-resources "tmpdir=system_tmpdir" \
+    --default-resources "tmpdir='${TEMP}'" \
     --snakefile workflow/process_sample.smk \
     2>&1 | tee "logs/process_sample.${SAMPLE}.$(date -d 'today' +'%Y%m%d%H%M').log"

--- a/process_sample.smk
+++ b/process_sample.smk
@@ -4,7 +4,7 @@ from pathlib import Path
 
 configfile: "workflow/reference.yaml"         # reference information
 configfile: "workflow/config.yaml"            # general configuration
-shell.prefix(f"set -o pipefail; umask 002; export TMPDIR={config['tmpdir']}; export SINGULARITY_TMPDIR={config['tmpdir']}; ")  # set g+w
+shell.prefix(f"set -o pipefail; umask 002; ")  # set g+w
 
 
 # sample will be provided at command line with `--config sample=$SAMPLE`
@@ -14,7 +14,7 @@ all_chroms = config['ref']['autosomes'] + config['ref']['sex_chrom'] + config['r
 print(f"Processing sample {sample} with reference {ref}.")
 
 # scan samples/{sample}/aligned to generate a dict of aBAMs
-pattern = re.compile(r'samples/(?P<sample>[A-Za-z0-9_-]+)/aligned/(?P<movie>m\d{5}[Ue]?_\d{6}_\d{6})\.(?P<reference>.*).bam')
+pattern = re.compile(r'samples/(?P<sample>[A-Za-z0-9_-]+)/aligned/(?P<movie>[A-Za-z0-9._-]+)\.(?P<reference>[A-Za-z0-9_-]+).bam')
 abam_dict = {}
 for infile in Path(f"samples/{sample}/aligned").glob('*.bam'):
     match = pattern.search(str(infile))
@@ -28,9 +28,9 @@ print(f"{sample} movies available: {movies}")
 
 # scan smrtcells/ready directory for uBAMs or FASTQs for hifiasm
 # uBAMs will have priority over FASTQs in downstream processes if both are available
-ubam_pattern = re.compile(r'smrtcells/ready/(?P<sample>[A-Za-z0-9_-]+)/(?P<movie>m\d{5}[Ue]?_\d{6}_\d{6}).(ccs|hifi_reads).bam')
+ubam_pattern = re.compile(r'smrtcells/ready/(?P<sample>[A-Za-z0-9_-]+)/(?P<movie>[A-Za-z0-9._-]+).bam')
 ubam_dict = {}
-fastq_pattern = re.compile(r'smrtcells/ready/(?P<sample>[A-Za-z0-9_-]+)/(?P<movie>m\d{5}[Ue]?_\d{6}_\d{6}).fastq.gz')
+fastq_pattern = re.compile(r'smrtcells/ready/(?P<sample>[A-Za-z0-9_-]+)/(?P<movie>[A-Za-z0-9._-]+).fastq.gz')
 fastq_dict = {}
 for infile in Path(f'smrtcells/ready/{sample}').glob('*.bam'):
     ubam_match = ubam_pattern.search(str(infile))

--- a/process_smrtcells.local.sh
+++ b/process_smrtcells.local.sh
@@ -5,6 +5,8 @@ umask 002
 
 mkdir -p logs
 
+source workflow/variables.env
+
 # execute snakemake
 snakemake --reason \
     --rerun-incomplete \
@@ -12,6 +14,6 @@ snakemake --reason \
     --keep-going \
     --cores 78 \
     --use-conda --conda-frontend mamba \
-    --default-resources "tmpdir=system_tmpdir" \
+    --default-resources "tmpdir='${TEMP}'" \
     --snakefile workflow/process_smrtcells.smk \
     2>&1 | tee "logs/process_smrtcells.$(date -d 'today' +'%Y%m%d%H%M').log"

--- a/process_smrtcells.smk
+++ b/process_smrtcells.smk
@@ -5,15 +5,15 @@ from collections import defaultdict
 
 configfile: "workflow/reference.yaml"         # reference configuration
 configfile: "workflow/config.yaml"            # general configuration
-shell.prefix(f"set -o pipefail; umask 002; export TMPDIR={config['tmpdir']}; export SINGULARITY_TMPDIR={config['tmpdir']}; ")  # set g+w
+shell.prefix(f"set -o pipefail; umask 002; ")  # set g+w
 
 ref = config['ref']['shortname']
 
 # scan smrtcells/ready directory for uBAMs or FASTQs that are ready to process
 # uBAMs have priority over FASTQs in downstream processes if both are available
-ubam_pattern = re.compile(r'smrtcells/ready/(?P<sample>[A-Za-z0-9_-]+)/(?P<movie>m\d{5}[Ue]?_\d{6}_\d{6}).(ccs|hifi_reads).bam')
+ubam_pattern = re.compile(r'smrtcells/ready/(?P<sample>[A-Za-z0-9_-]+)/(?P<movie>[A-Za-z0-9._-]+).bam')
 ubam_dict = defaultdict(dict)
-fastq_pattern = re.compile(r'smrtcells/ready/(?P<sample>[A-Za-z0-9_-]+)/(?P<movie>m\d{5}[Ue]?_\d{6}_\d{6}).fastq.gz')
+fastq_pattern = re.compile(r'smrtcells/ready/(?P<sample>[A-Za-z0-9_-]+)/(?P<movie>[A-Za-z0-9._-]+).fastq.gz')
 fastq_dict = defaultdict(dict)
 for infile in Path('smrtcells/ready').glob('**/*.bam'):
     ubam_match = ubam_pattern.search(str(infile))

--- a/variables.env
+++ b/variables.env
@@ -1,0 +1,1 @@
+TEMP=/scratch

--- a/variables.env
+++ b/variables.env
@@ -1,1 +1,1 @@
-TEMP=/scratch
+export TEMP=/scratch


### PR DESCRIPTION
- Allows tmpdir for snakemake and singularity to be specified in `variables.env`
- Changed regex for hifi reads and abams to be more flexible in movie name
- Commented out lockfile commands in `process_sample.local.sh` `process_cohort.local.sh` for customer