### PR TITLE
Add yak triobin output

### DIFF
--- a/process_cohort.cluster.yaml
+++ b/process_cohort.cluster.yaml
@@ -26,3 +26,5 @@ samtools_index_bam:
   cpus: 4
 yak_trioeval:
   cpus: 16
+yak_triobin:
+  cpus: 16

--- a/process_cohort.smk
+++ b/process_cohort.smk
@@ -125,6 +125,10 @@ include: 'rules/cohort_common.smk'
 # assemble with hifiasm
 include: 'rules/cohort_hifiasm.smk'
 if 'trio_assembly' in config['cohort_targets']:
+    # triobin tables
+    targets.extend([f"cohorts/{cohort}/yak/{trio}.{movie}.triobin.txt"
+                    for movie in ubam_fastq_dict[trio]
+                    for trio in trio_dict.keys()])
     # assembly and stats
     targets.extend([f"cohorts/{cohort}/hifiasm/{trio}.asm.dip.{infix}.{suffix}"
                 for suffix in ['fasta.gz', 'fasta.stats.txt', 'fasta.trioeval.txt']

--- a/process_cohort.smk
+++ b/process_cohort.smk
@@ -127,8 +127,8 @@ include: 'rules/cohort_hifiasm.smk'
 if 'trio_assembly' in config['cohort_targets']:
     # triobin tables
     targets.extend([f"cohorts/{cohort}/yak/{trio}.{movie}.triobin.txt"
-                    for movie in ubam_fastq_dict[trio]
-                    for trio in trio_dict.keys()])
+                    for trio in trio_dict.keys()
+                    for movie in ubam_fastq_dict[trio]])
     # assembly and stats
     targets.extend([f"cohorts/{cohort}/hifiasm/{trio}.asm.dip.{infix}.{suffix}"
                 for suffix in ['fasta.gz', 'fasta.stats.txt', 'fasta.trioeval.txt']


### PR DESCRIPTION
Using `yak triobin`, add a table assigning each trio child read to parent of origin, using the same parameters as for hifiasm trio assembly.

Output can be used to label reads with parent of origin.