### PR TITLE
bcftools dependency and jellyfish disk flag

### DIFF
--- a/rules/envs/bcftools.yaml
+++ b/rules/envs/bcftools.yaml
@@ -1,5 +1,7 @@
 channels:
   - bioconda
   - conda-forge
+  - defaults
 dependencies:
+  - gsl=2.6
   - bcftools=1.14

--- a/rules/envs/slivar.yaml
+++ b/rules/envs/slivar.yaml
@@ -1,7 +1,9 @@
 channels:
   - bioconda
   - conda-forge
+  - defaults
 dependencies:
+  - gsl=2.6
   - slivar==0.2.2
   - bcftools=1.14
   - vcfpy==0.13.3

--- a/rules/smrtcell_jellyfish.smk
+++ b/rules/smrtcell_jellyfish.smk
@@ -30,7 +30,7 @@ rule jellyfish_count:
     params:
         kmer_length = config['kmer_length'],
         size = 1000000000,
-        extra = "--canonical"
+        extra = "--canonical --disk"
     threads: 24
     conda: "envs/jellyfish.yaml"
     message: "Executing {rule}: Counting {params.kmer_length}mers in {input}."


### PR DESCRIPTION
- forces environments with bcftools use a compatible version of gsl
- prevents jellyfish from automatically resizing hash tables, which can prevent merging among movies