### PR TITLE
Sort normalized BCF

### DIFF
--- a/rules/cohort_slivar.smk
+++ b/rules/cohort_slivar.smk
@@ -45,7 +45,7 @@ rule bcftools_norm:
     params: f"--multiallelics - --output-type b --fasta-ref {config['ref']['fasta']}"
     conda: "envs/bcftools.yaml"
     message: "Executing {rule}: Splitting multiallelic sites and normalizing indels for {input.vcf}."
-    shell: "(bcftools norm {params} {input.vcf} -o {output}) > {log} 2>&1"
+    shell: "(bcftools norm {params} {input.vcf} | bcftools sort --output-type b -o {output}) > {log} 2>&1"
 
 
 slivar_filters = [


### PR DESCRIPTION
`bcftools norm` does not sort the normalized BCF, and `tabix` can't index an unsorted BCF.  Changed command to sort normalized BCF inline.

I've noticed this bug in 3 cohorts since incrementing `bcftools` to version 1.14 in January.  Not sure why it didn't pop up before, but seems smart to sort the input before running `tabix`.