### PR TITLE
move deepvariant HPC configuration to variables.env

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,10 +29,14 @@ kmer_length: 21
 # pass along extra parameters to pbsv that will override the hifi defaults
 pbsv_call_extra: ""
 
-# deepvariant
-#DEEPVARIANT_VERSION: '1.4.0'  # CPU-only, will require modifying threads for call_variants rules
-DEEPVARIANT_VERSION: '1.4.0-gpu'  # GPU
+# deepvariant 
 N_SHARDS: 256
+# deepvariant call_variants can be run as GPU or CPU-only
+# additional configuration specific to job schedulers can be found variables.env
+# change to True if you don't have GPUs available
+cpu_only: False
+deepvariant_cpu_version: '1.4.0'
+deepvariant_gpu_version: '1.4.0-gpu'
 
 # glnexus
 GLNEXUS_VERSION: 'v1.4.1'

--- a/process_sample.local.sh
+++ b/process_sample.local.sh
@@ -20,7 +20,7 @@ mkdir -p logs
 
 # execute snakemake
 snakemake \
-    --config sample=${SAMPLE} cpu_only=True \
+    --config sample=${SAMPLE} \
     --nolock \
     --profile workflow/profiles/local \
     --snakefile workflow/process_sample.smk \

--- a/variables.env
+++ b/variables.env
@@ -3,3 +3,14 @@ export PARTITION=compute
 export ACCOUNT=100humans
 export SINGULARITY_TMPDIR="$TMPDIR"
 export SINGULARITY_BIND="$TMPDIR"
+
+# deepvariant make_examples and postprocess_variants require at least avx2
+# this can be commented out if your scheduler doesn't constrain nodes in this way
+export DEEPVARIANT_AVX2_CONSTRAINT='--constraint=avx512'
+
+# these are required and apply if cpu_only=False in config.yaml
+export DEEPVARIANT_GPU_PARTITION=ml
+export DEEPVARIANT_GPU_EXTRA='--gpus=1'
+
+# this is optional and applies if cpu_only=True in config.yaml
+export DEEPVARIANT_CPU_EXTRA='--exclusive'


### PR DESCRIPTION
Makes DeepVariant steps more portable. Tried to keep scheduler-specific configuration in `variables.env` and instead of `config.yaml`.

Resolves #89 