### PR TITLE
remove message directives from each rule

### DIFF
--- a/rules/cohort_common.smk
+++ b/rules/cohort_common.smk
@@ -8,7 +8,6 @@ rule bgzip_vcf:
     benchmark: f"cohorts/{cohort}/benchmarks/bgzip/{{prefix}}.tsv"
     threads: 2
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Compressing {input}."
     shell: "(bgzip --threads {threads} {input}) > {log} 2>&1"
 
 
@@ -19,7 +18,6 @@ rule tabix_vcf:
     benchmark: f"cohorts/{cohort}/benchmarks/tabix/index/{{prefix}}.tsv"
     params: "-p vcf"
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Indexing {input}."
     shell: "(tabix {params} {input}) > {log} 2>&1"
 
 
@@ -30,7 +28,6 @@ rule tabix_bcf:
     benchmark: f"cohorts/{cohort}/benchmarks/tabix/index/{{prefix}}.tsv"
     params: "-p bcf"
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Indexing {input}."
     shell: "(tabix {params} {input}) > {log} 2>&1"
 
 
@@ -39,7 +36,6 @@ rule create_ped:
     output: f"cohorts/{cohort}/{cohort}.ped"
     log: f"cohorts/{cohort}/logs/yaml2ped/{cohort}.log"
     conda: "envs/pyyaml.yaml"
-    message: f"Executing {{rule}}: Creating pedigree file for {cohort}."
     shell: f"(python3 workflow/scripts/yaml2ped.py {{input}} {cohort} {{output}}) > {{log}} 2>&1"
 
 
@@ -53,7 +49,6 @@ rule calculate_phrank:
     output: f"cohorts/{cohort}/{cohort}_phrank.tsv"
     log: f"cohorts/{cohort}/logs/calculate_phrank/{cohort}.log"
     conda: "envs/pyyaml.yaml"
-    message: f"Executing {{rule}}: Calculate Phrank scores for {cohort}."
     shell:
         f"""(python3 workflow/scripts/calculate_phrank.py \
         {{input.hpoterms}} {{input.hpodag}} {{input.hpoannotations}} \

--- a/rules/cohort_glnexus.smk
+++ b/rules/cohort_glnexus.smk
@@ -14,7 +14,6 @@ rule glnexus:
         mem_gbytes = 192,
     container: f"docker://ghcr.io/dnanexus-rnd/glnexus:{config['GLNEXUS_VERSION']}"
     threads: 24
-    message: f"Executing {{rule}}: Joint calling variants from {cohort} cohort."
     shell:
         """
         (rm -rf {output.scratch_dir} && \
@@ -32,7 +31,6 @@ rule bcftools_bcf2vcf:
     params: "--threads 4 -Oz"
     threads: 4
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Converting GLnexus BCF to VCF for {input}."
     shell: "(bcftools view {params} {input} -o {output}) > {log} 2>&1"
 
 
@@ -45,7 +43,6 @@ rule split_glnexus_vcf:
     benchmark: f"cohorts/{cohort}/benchmarks/tabix/query/{cohort}.{ref}.{{region}}.glnexus.vcf.tsv"
     params: region = lambda wildcards: wildcards.region, extra = '-h'
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Extracting {wildcards.region} variants from {input}."
     shell: "(tabix {params.extra} {input.vcf} {params.region} > {output}) 2> {log}"
 
 
@@ -63,7 +60,6 @@ rule whatshap_phase:
         chromosome = lambda wildcards: wildcards.chromosome,
         extra = "--indels"
     conda: "envs/whatshap.yaml"
-    message: "Executing {rule}: Phasing {input.vcf} using {input.phaseinput} for chromosome {wildcards.chromosome}."
     shell:
         """
         (whatshap phase {params.extra} \
@@ -87,7 +83,6 @@ rule whatshap_bcftools_concat:
     benchmark: f"cohorts/{cohort}/benchmarks/bcftools/concat/{cohort}.{ref}.whatshap.tsv"
     params: "-a -Oz"
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Concatenating WhatsHap phased VCFs: {input.calls}"
     shell: "(bcftools concat {params} -o {output} {input.calls}) > {log} 2>&1"
 
 
@@ -103,7 +98,6 @@ rule whatshap_stats:
     log: f"cohorts/{cohort}/logs/whatshap/stats/{cohort}.{ref}.log"
     benchmark: f"cohorts/{cohort}/benchmarks/whatshap/stats/{cohort}.{ref}.tsv"
     conda: "envs/whatshap.yaml"
-    message: "Executing {rule}: Calculating phasing stats for {input.vcf}."
     shell:
         """
         (whatshap stats \

--- a/rules/cohort_hifiasm.smk
+++ b/rules/cohort_hifiasm.smk
@@ -9,7 +9,6 @@ rule samtools_fasta:
     benchmark: f"cohorts/{cohort}/benchmarks/samtools/fasta/{{sample}}/{{movie}}.tsv"
     threads: 4
     conda: "envs/samtools.yaml"
-    message: "Executing {rule}: Converting {input} to {output}."
     shell: "(samtools fasta -@ 3 {input} > {output}) > {log} 2>&1"
 
 
@@ -19,7 +18,6 @@ rule seqtk_fastq_to_fasta:
     log: f"cohorts/{cohort}/logs/seqtk/seq/{{sample}}/{{movie}}.log"
     benchmark: f"cohorts/{cohort}/benchmarks/seqtk/seq/{{sample}}/{{movie}}.tsv"
     conda: "envs/seqtk.yaml"
-    message: "Executing {rule}: Converting {input} to {output}."
     shell: "(seqtk seq -A {input} > {output}) > {log} 2>&1"
 
 
@@ -30,7 +28,6 @@ rule yak_count:
     benchmark: f"cohorts/{cohort}/benchmarks/yak/{{sample}}.yak.tsv"
     conda: "envs/yak.yaml"
     threads: 32
-    message: "Executing {rule}: Counting k-mers in {input}."
     shell: "(yak count -t {threads} -o {output} {input}) > {log} 2>&1"
 
 
@@ -64,7 +61,6 @@ rule hifiasm_assemble:
         parent2 = lambda wildcards: trio_dict[wildcards.sample]['parent2'],
         extra = "-c1 -d1"
     threads: 48
-    message: "Executing {rule}: Assembling sample {wildcards.sample} from {input.fasta} and parental k-mers."
     shell:
             """
             (
@@ -81,7 +77,6 @@ rule gfa2fa:
     log: f"cohorts/{cohort}/logs/gfa2fa/{{sample}}.asm.dip.{{infix}}.log"
     benchmark: f"cohorts/{cohort}/benchmarks/gfa2fa/{{sample}}.asm.dip.{{infix}}.tsv"
     conda: "envs/gfatools.yaml"
-    message: "Executing {rule}: Extracting fasta from assembly {input}."
     shell: "(gfatools gfa2fa {input} > {output}) 2> {log}"
 
 
@@ -92,7 +87,6 @@ rule bgzip_fasta:
     benchmark: f"cohorts/{cohort}/benchmarks/bgzip/{{sample}}.asm.dip.{{infix}}.tsv"
     threads: 4
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Compressing {input}."
     shell: "(bgzip --threads {threads} {input}) > {log} 2>&1"
 
 
@@ -114,7 +108,6 @@ rule asm_stats:
     log: f"cohorts/{cohort}/logs/asm_stats/{{sample}}.asm.dip.{{infix}}.fasta.log"
     benchmark: f"cohorts/{cohort}/benchmarks/asm_stats/{{sample}}.asm.dip.{{infix}}.fasta.tsv"
     conda: "envs/k8.yaml"
-    message: "Executing {rule}: Calculating stats for {input}."
     shell: f"(k8 workflow/scripts/calN50/calN50.js -f {config['ref']['index']} {{input}} > {{output}}) > {{log}} 2>&1"
 
 
@@ -134,7 +127,6 @@ rule align_hifiasm:
         samtools_mem = "8G"
     threads: 16  # minimap2 + samtools(+3)
     conda: "envs/align_hifiasm.yaml"
-    message: "Executing {rule}: Aligning {input.query} to {input.target}."
     shell:
         """
         (minimap2 -t {params.minimap2_threads} {params.minimap2_args} -R '{params.readgroup}' {input.target} {input.query} \
@@ -149,5 +141,4 @@ rule samtools_index_bam:
     benchmark: f"cohorts/{cohort}/logs/samtools/index/{{prefix}}.tsv"
     threads: 4
     conda: "envs/samtools.yaml"
-    message: "Executing {rule}: Indexing {input}."
     shell: "(samtools index -@ 3 {input}) > {log} 2>&1"

--- a/rules/cohort_pbsv.smk
+++ b/rules/cohort_pbsv.smk
@@ -14,7 +14,6 @@ rule pbsv_call:
         loglevel = "INFO"
     threads: 8
     conda: "envs/pbsv.yaml"
-    message: "Executing {rule}: Calling structural variants in {wildcards.region} from SVSIGs: {input.svsigs}"
     shell:
         """
         (pbsv call {params.extra} \
@@ -32,5 +31,4 @@ rule bcftools_concat_pbsv_vcf:
     log: f"cohorts/{cohort}/logs/bcftools/concat/{cohort}.{ref}.pbsv.vcf.log"
     benchmark: f"cohorts/{cohort}/benchmarks/bcftools/concat/{cohort}.{ref}.pbsv.vcf.tsv"
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Concatenating pbsv VCFs: {input.calls}"
     shell: "(bcftools concat -a -o {output} {input.calls}) > {log} 2>&1"

--- a/rules/cohort_slivar.smk
+++ b/rules/cohort_slivar.smk
@@ -6,7 +6,6 @@ rule reformat_ensembl_gff:
     log: "logs/reformat_ensemble_gff.log"
     params: url = config['ref']['ensembl_gff_url']
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Downloaded and reformatting ensembl GFF to {output}."
     shell:
         """
         (wget -qO - {params.url} | zcat \
@@ -19,7 +18,6 @@ rule generate_lof_lookup:
     output: config['lof_lookup']
     log: "logs/generate_lof_lookup.log"
     params: url = config['lof_lookup_url']
-    message: "Executing {rule}: Generating a lookup table for loss-of-function metrics at {output}."
     shell:
         """
         (wget -qO - {params.url} | zcat | cut -f 1,21,24 | tail -n+2 \
@@ -31,7 +29,6 @@ rule generate_clinvar_lookup:
     output: config['clinvar_lookup']
     log: "logs/generate_clinvar_lookup.log"
     params: url = config['clinvar_lookup_url']
-    message: "Executing {rule}: Generating a lookup table for clinvar gene descriptions at {output}."
     shell: "(wget -qO - {params.url} | cut -f 2,5 | grep -v ^$'\t' > {output}) > {log} 2>&1"
 
 
@@ -44,7 +41,6 @@ rule bcftools_norm:
     benchmark: f"cohorts/{cohort}/benchmarks/bcftools/norm/{cohort}.{ref}.deepvariant.phased.vcf.tsv"
     params: f"--multiallelics - --output-type b --fasta-ref {config['ref']['fasta']}"
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Splitting multiallelic sites and normalizing indels for {input.vcf}."
     shell: "(bcftools norm {params} {input.vcf} | bcftools sort --output-type b -o {output}) > {log} 2>&1"
 
 
@@ -83,7 +79,6 @@ rule slivar_small_variant:
     params: filters = slivar_filters
     threads: 12
     conda: "envs/slivar.yaml"
-    message: "Executing {rule}: Annotating {input.bcf} and applying filters."
     shell:
         """
         (pslivar --processes {threads} \
@@ -125,7 +120,6 @@ rule slivar_compound_hets:
     benchmark: f"cohorts/{cohort}/benchmarks/slivar/compound-hets/{cohort}.{ref}.deepvariant.phased.slivar.compound-hets.vcf.tsv"
     params: skip = ",".join(skip_list)
     conda: "envs/slivar.yaml"
-    message: f"Executing {{rule}}: Finding compound hets in {cohort}."
     shell:
         """
         (slivar compound-hets \
@@ -164,7 +158,6 @@ rule slivar_tsv:
     benchmark: f"cohorts/{cohort}/benchmarks/slivar/tsv/{cohort}.{ref}.tsv"
     params: info = "".join([f"--info-field {x} " for x in info_fields])
     conda: "envs/slivar.yaml"
-    message: "Executing {rule}: Converting annotated VCFs to TSVs for easier interpretation."
     shell:
         """
         (slivar tsv \

--- a/rules/cohort_svpack.smk
+++ b/rules/cohort_svpack.smk
@@ -51,7 +51,6 @@ rule slivar_svpack_tsv:
     benchmark: f"cohorts/{cohort}/benchmarks/slivar/tsv/{cohort}.{ref}.pbsv.svpack.tsv"
     params: info = "".join([f"--info-field {x} " for x in info_fields])
     conda: "envs/slivar.yaml"
-    message: "Executing {rule}: Converting annotated VCFs to TSVs for easier interpretation."
     shell:
         """
         (slivar tsv \

--- a/rules/sample_common.smk
+++ b/rules/sample_common.smk
@@ -8,7 +8,6 @@ rule bgzip_vcf:
     benchmark: f"samples/{sample}/benchmarks/bgzip/{{prefix}}.tsv"
     threads: 2
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Compressing {input}."
     shell: "(bgzip --threads {threads} {input}) > {log} 2>&1"
 
 
@@ -19,7 +18,6 @@ rule tabix_vcf:
     benchmark: f"samples/{sample}/benchmarks/tabix/index/{{prefix}}.tsv"
     params: "-p vcf"
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Indexing {input}."
     shell: "tabix {params} {input} > {log} 2>&1"
 
 
@@ -30,5 +28,4 @@ rule samtools_index_bam:
     benchmark: f"samples/{sample}/logs/samtools/index/{{prefix}}.tsv"
     threads: 4
     conda: "envs/samtools.yaml"
-    message: "Executing {rule}: Indexing {input}."
     shell: "(samtools index -@ 3 {input}) > {log} 2>&1"

--- a/rules/sample_deepvariant.smk
+++ b/rules/sample_deepvariant.smk
@@ -25,7 +25,6 @@ rule deepvariant_make_examples:
         reads = ','.join(abams)
     resources: 
         extra = '--constraint=avx512'
-    message: "Executing {rule}: DeepVariant make_examples {wildcards.shard} for {input.bams}."
     shell:
         f"""
         (/opt/deepvariant/bin/make_examples \
@@ -57,7 +56,6 @@ rule deepvariant_call_variants_gpu:
     benchmark: f"samples/{sample}/benchmarks/deepvariant/call_variants/{sample}.{ref}.tsv"
     container: f"docker://google/deepvariant:{deepvariant_version}"
     params: model = "/opt/models/pacbio/model.ckpt"
-    message: "Executing {rule}: DeepVariant call_variants for {input}."
     threads: deepvariant_threads
     resources:
         partition = 'ml',
@@ -89,7 +87,6 @@ rule deepvariant_postprocess_variants:
     threads: 4
     resources: 
         extra = '--constraint=avx512'
-    message: "Executing {rule}: DeepVariant postprocess_variants for {input.tfrecord}."
     shell:
         f"""
         (/opt/deepvariant/bin/postprocess_variants \
@@ -109,7 +106,6 @@ rule deepvariant_bcftools_stats:
     params: f"--fasta-ref {config['ref']['fasta']} --apply-filters PASS -s {sample}"
     threads: 4
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Calculating VCF statistics for {input}."
     shell: "(bcftools stats --threads 3 {params} {input} > {output}) > {log} 2>&1"
 
 
@@ -120,7 +116,6 @@ rule deepvariant_bcftools_roh:
     benchmark: f"samples/{sample}/benchmarks/bcftools/stats/{sample}.{ref}.deepvariant.vcf.tsv"
     params: default_allele_frequency = 0.4
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Calculating runs of homozygosity for {input}."
     shell:
         """
         (echo -e "#chr\tstart\tend\tqual" > {output}

--- a/rules/sample_gc_coverage.smk
+++ b/rules/sample_gc_coverage.smk
@@ -9,7 +9,6 @@ rule calculate_sample_gc_coverage:
     log: f"samples/{{sample}}/logs/quality_control/calculate_gc_coverage.{{sample}}.{ref}.log"
     benchmark: f"samples/{{sample}}/benchmarks/quality_control/calculate_gc_coverage.{{sample}}.{ref}.tsv"
     conda: "envs/gc_coverage.yaml"
-    message: "Executing {rule}: Calculating GC coverage distribution from mosdepth coverage by region for {input.mosdepth_regions}."
     shell:
         """
         (bedtools nuc -fi {input.ref} -bed {input.mosdepth_regions} \

--- a/rules/sample_hifiasm.smk
+++ b/rules/sample_hifiasm.smk
@@ -9,7 +9,6 @@ rule samtools_fasta:
     benchmark: f"samples/{sample}/benchmarks/samtools/fasta/{{movie}}.tsv"
     threads: 4
     conda: "envs/samtools.yaml"
-    message: "Converting {input} to {output}."
     shell: "(samtools fasta -@ 3 {input} > {output}) > {log} 2>&1"
 
 
@@ -19,7 +18,6 @@ rule seqtk_fastq_to_fasta:
     log: f"samples/{sample}/logs/seqtk/seq/{{movie}}.log"
     benchmark: f"samples/{sample}/benchmarks/seqtk/seq/{{movie}}.tsv"
     conda: "envs/seqtk.yaml"
-    message: "Converting {input} to {output}."
     shell: "(seqtk seq -A {input} > {output}) > {log} 2>&1"
 
 
@@ -43,7 +41,6 @@ rule hifiasm_assemble:
     conda: "envs/hifiasm.yaml"
     params: prefix = f"samples/{sample}/hifiasm/{sample}.asm"
     threads: 48
-    message: f"Assembling sample {sample} from {{input}}"
     shell: "(hifiasm -o {params.prefix} -t {threads} {input}) > {log} 2>&1"
 
 
@@ -53,7 +50,6 @@ rule gfa2fa:
     log: f"samples/{sample}/logs/gfa2fa/{sample}.asm.bp.{{infix}}.log"
     benchmark: f"samples/{sample}/benchmarks/gfa2fa/{sample}.asm.bp.{{infix}}.tsv"
     conda: "envs/gfatools.yaml"
-    message: "Extracting fasta from assembly {input}."
     shell: "(gfatools gfa2fa {input} > {output}) 2> {log}"
 
 
@@ -64,7 +60,6 @@ rule bgzip_fasta:
     benchmark: f"samples/{sample}/benchmarks/bgzip/{sample}.asm.bp.{{infix}}.tsv"
     threads: 4
     conda: "envs/htslib.yaml"
-    message: "Compressing {input}."
     shell: "(bgzip --threads {threads} {input}) > {log} 2>&1"
 
 
@@ -74,7 +69,6 @@ rule asm_stats:
     log: f"samples/{sample}/logs/asm_stats/{sample}.asm.bp.{{infix}}.fasta.log"
     benchmark: f"samples/{sample}/benchmarks/asm_stats/{sample}.asm.bp.{{infix}}.fasta.tsv"
     conda: "envs/k8.yaml"
-    message: "Calculating stats for {input}."
     shell: f"(k8 workflow/scripts/calN50/calN50.js -f {config['ref']['index']} {{input}} > {{output}}) > {{log}} 2>&1"
 
 
@@ -94,7 +88,6 @@ rule align_hifiasm:
         samtools_mem = "8G"
     threads: 16  # minimap2 + samtools(+3)
     conda: "envs/align_hifiasm.yaml"
-    message: "Aligning {input.query} to {input.target}."
     shell:
         """
         (minimap2 -t {params.minimap2_threads} {params.minimap2_args} -R '{params.readgroup}' {input.target} {input.query} \
@@ -112,7 +105,6 @@ rule htsbox:
     benchmark: f"samples/{sample}/benchmarks/htsbox/{sample}.asm.tsv"
     params: '-q20'
     conda: "envs/htsbox.yaml"
-    message: "Calling variants from {{input.bam}} using htsbox."
     shell: "(htsbox pileup {params} -c -f {input.reference} {input.bam} > {output})> {log} 2>&1"
 
 
@@ -124,5 +116,4 @@ rule htsbox_bcftools_stats:
     params: f"--fasta-ref {config['ref']['fasta']} -s samples/{sample}/hifiasm/{sample}.asm.{ref}.bam"
     threads: 4
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Calculating VCF statistics for {input}."
     shell: "(bcftools stats --threads 3 {params} {input} > {output}) > {log} 2>&1"

--- a/rules/sample_jellyfish.smk
+++ b/rules/sample_jellyfish.smk
@@ -4,7 +4,6 @@ rule jellyfish_merge:
     log: f"samples/{sample}/logs/jellyfish/merge/{sample}.log"
     benchmark: f"samples/{sample}/benchmarks/jellyfish/merge/{sample}.tsv"
     conda: "envs/jellyfish.yaml"
-    message: "Executing {rule}: Merging per-smrtcell jellyfish counts to create {output}."
     shell:
         f"""
         if [[ "{{input}}" =~ " " ]]

--- a/rules/sample_kmer_consistency.smk
+++ b/rules/sample_kmer_consistency.smk
@@ -6,5 +6,4 @@ rule check_kmer_consistency:
     log: f"samples/{sample}/logs/jellyfish/kmerconsistency/{sample}.log"
     benchmark: f"samples/{sample}/benchmarks/jellyfish/kmerconsistency/{sample}.tsv"
     conda: "envs/base_python3.yaml"
-    message: "Executing {rule}: Output kmer consistency to create {output}."
     shell: "(python3 workflow/scripts/check_kmer_consistency.py {input.ref_modimers} {input.movie_modimers} > {output}) > {log} 2>&1"

--- a/rules/sample_mosdepth.smk
+++ b/rules/sample_mosdepth.smk
@@ -15,7 +15,6 @@ rule mosdepth:
         extra = "--no-per-base --use-median"
     threads: 4
     conda: "envs/mosdepth.yaml"
-    message: "Executing {rule}: Calculating coverage of {input.bam} using mosdepth."
     shell:
         """
         (mosdepth --threads {threads} --by {params.by} \

--- a/rules/sample_pbsv.smk
+++ b/rules/sample_pbsv.smk
@@ -19,7 +19,6 @@ rule pbsv_discover:
         region = lambda wildcards: wildcards.region,
         loglevel = "INFO"
     conda: "envs/pbsv.yaml"
-    message: "Executing {rule}: Discovering structural variant signatures in {wildcards.region} from {input.bam}."
     shell:
         """
         (pbsv discover {params.extra} \
@@ -43,7 +42,6 @@ rule pbsv_call:
         loglevel = "INFO"
     threads: 8
     conda: "envs/pbsv.yaml"
-    message: "Executing {rule}: Calling structural variants in {wildcards.region} from SVSIGs: {input.svsigs}"
     shell:
         """
         (pbsv call {params.extra} \
@@ -61,7 +59,6 @@ rule bcftools_concat_pbsv_vcf:
     log: f"samples/{sample}/logs/bcftools/concat/{sample}.{ref}.pbsv.vcf.log"
     benchmark: f"samples/{sample}/benchmarks/bcftools/concat/{sample}.{ref}.pbsv.vcf.tsv"
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Concatenating pbsv VCFs: {input.calls}"
     shell: "(bcftools concat -a -o {output} {input.calls}) > {log} 2>&1"
 
 

--- a/rules/sample_tandem_genotypes.smk
+++ b/rules/sample_tandem_genotypes.smk
@@ -5,7 +5,6 @@ rule download_tg_list:
     output: config['ref']['tg_list']
     log: "logs/download_tg_list.log"
     params: url = config['ref']['tg_list_url']
-    message: "Executing {rule}: Downloading a list of loci with disease-associated repeats to {output}."
     shell: "(wget -qO - {params.url} > {output}) > {log} 2>&1"
 
 
@@ -17,7 +16,6 @@ rule generate_tg_bed:
     log: "logs/generate_tg_bed.log"
     conda: "envs/bedtools.yaml"
     params: slop = 1000
-    message: "Executing {rule}: Adding {params.slop}bp slop to {input.tg_list} to generate {output}."
     shell: 
         """
         (grep -v '^#' {input.tg_list} | sort -k1,1V -k2,2g \
@@ -35,7 +33,6 @@ rule generate_last_index:
     conda: "envs/last.yaml"
     params: "-uRY32 -R01"
     threads: 24
-    message: "Executing {rule}: Generating last index of {input} using params: {params}"
     shell: f"(lastdb -P{{threads}} {{params}} {config['ref']['last_index']} {{input}}) > {{log}} 2>&1"
 
 
@@ -55,7 +52,6 @@ rule last_align:
         last_index = config['ref']['last_index'],
         extra = "-C2"
     threads: 24
-    message: "Executing {rule}: Aligning {input.bed} regions of {input.bam} to {params.last_index} using lastal with {input.score_matrix} score matrix."
     shell:
         """
         (samtools view -@3 -bL {input.bed} {input.bam} | samtools fasta \
@@ -72,7 +68,6 @@ rule tandem_genotypes:
     log: f"samples/{sample}/logs/tandem-genotypes/{sample}.log"
     benchmark: f"samples/{sample}/benchmarks/tandem-genotypes/{sample}.tsv"
     conda: "envs/tandem-genotypes.yaml"
-    message: "Executing {rule}: Genotyping tandem repeats from {input.repeats} regions in {input.maf}."
     shell: "(tandem-genotypes {input.repeats} {input.maf} > {output}) > {log} 2>&1"
 
 
@@ -81,7 +76,6 @@ rule tandem_genotypes_absolute_count:
     output: f"samples/{sample}/tandem-genotypes/{sample}.tandem-genotypes.absolute.txt"
     log: f"samples/{sample}/logs/tandem-genotypes/{sample}.absolute.log"
     benchmark: f"samples/{sample}/benchmarks/tandem-genotypes/{sample}.absolute.tsv"
-    message: "Executing {rule}: Adjusting repeat count with reference counts for {input}."
     shell:
         """
         (awk -v OFS='\t' \
@@ -109,7 +103,6 @@ rule tandem_genotypes_plot:
     benchmark: f"samples/{sample}/benchmarks/tandem-genotypes/plot/{sample}.tsv"
     conda: "envs/tandem-genotypes.yaml"
     params: top_N_plots = 100
-    message: "Executing {rule}: Plotting tandem repeats from {input}."
     shell: "(tandem-genotypes-plot -n {params.top_N_plots} {input} {output}) > {log} 2>&1"
 
 
@@ -122,5 +115,4 @@ rule tandem_repeat_coverage_dropouts:
     log: f"samples/{sample}/logs/tandem-genotypes/{sample}.dropouts.log"
     benchmark: f"samples/{sample}/benchmarks/tandem-genotypes/{sample}.dropouts.tsv"
     conda: "envs/tandem-genotypes.yaml"
-    message: "Executing {rule}: Identify coverage dropouts in {input.bed} regions in {input.bam}."
     shell: "(python3 workflow/scripts/check_tandem_repeat_coverage.py {input.bed} {input.bam} > {output}) > {log} 2>&1"

--- a/rules/sample_whatshap.smk
+++ b/rules/sample_whatshap.smk
@@ -8,7 +8,6 @@ rule split_deepvariant_vcf:
     benchmark: f"samples/{sample}/benchmarks/tabix/query/{sample}.{ref}.{{region}}.deepvariant.vcf.tsv"
     params: region = lambda wildcards: wildcards.region, extra = '-h'
     conda: "envs/htslib.yaml"
-    message: "Executing {rule}: Extracting {wildcards.region} variants from {input}."
     shell: "tabix {params.extra} {input} {params.region} > {output} 2> {log}"
 
 
@@ -24,7 +23,6 @@ rule whatshap_phase:
     benchmark: f"samples/{sample}/benchmarks/whatshap/phase/{sample}.{ref}.{{chromosome}}.tsv"
     params: chromosome = lambda wildcards: wildcards.chromosome, extra = "--indels"
     conda: "envs/whatshap.yaml"
-    message: "Executing {rule}: Phasing {input.vcf} using {input.phaseinput} for chromosome {wildcards.chromosome}."
     shell:
         """
         (whatshap phase {params.extra} \
@@ -45,7 +43,6 @@ rule whatshap_bcftools_concat:
     benchmark: f"samples/{sample}/benchmarks/bcftools/concat/{sample}.{ref}.whatshap.tsv"
     params: "-a -Oz"
     conda: "envs/bcftools.yaml"
-    message: "Executing {rule}: Concatenating WhatsHap phased VCFs: {input.calls}"
     shell: "bcftools concat {params} -o {output} {input.calls} > {log} 2>&1"
 
 
@@ -61,7 +58,6 @@ rule whatshap_stats:
     log: f"samples/{sample}/logs/whatshap/stats/{sample}.{ref}.log"
     benchmark: f"samples/{sample}/benchmarks/whatshap/stats/{sample}.{ref}.tsv"
     conda: "envs/whatshap.yaml"
-    message: "Executing {rule}: Calculating phasing stats for {input.vcf}."
     shell:
         """
         (whatshap stats \
@@ -84,7 +80,6 @@ rule whatshap_haplotag:
     benchmark: f"samples/{sample}/benchmarks/whatshap/haplotag/{sample}.{ref}.{{movie}}.tsv"
     params: "--tag-supplementary"
     conda: "envs/whatshap.yaml"
-    message: "Executing {rule}: Haplotagging {input.bam} using phase information from {input.vcf}."
     shell:
         """
         (whatshap haplotag {params} \
@@ -101,7 +96,6 @@ rule merge_haplotagged_bams:
     benchmark: f"samples/{sample}/benchmarks/samtools/merge/{sample}.{ref}.haplotag.tsv"
     threads: 8
     conda: "envs/samtools.yaml"
-    message: "Executing {rule}: Merging {input}."
     shell:
         """
         if [[ "{input}" =~ " " ]]

--- a/rules/smrtcell_coverage_qc.smk
+++ b/rules/smrtcell_coverage_qc.smk
@@ -7,7 +7,6 @@ rule infer_sex_from_coverage:
     log: f"samples/{{sample}}/logs/quality_control/infer_sex_from_coverage.{{movie}}.{ref}.log"
     benchmark: f"samples/{{sample}}/benchmarks/quality_control/infer_sex_from_coverage.{{movie}}.{ref}.tsv"
     conda: "envs/pandas.yaml"
-    message: "Executing {rule}: Inferring chromosomal sex from mosdepth coverage summary {input}."
     shell: "(python3 workflow/scripts/infer_sex_from_coverage.py {input} > {output}) > {log} 2>&1"
 
 
@@ -17,7 +16,6 @@ rule calculate_m2_ratio:
     log: f"samples/{{sample}}/logs/quality_control/calculate_M2_ratio.{{movie}}.{ref}.log"
     benchmark: f"samples/{{sample}}/benchmarks/quality_control/calculate_M2_ratio.{{movie}}.{ref}.tsv"
     conda: "envs/pandas.yaml"
-    message: "Executing {rule}: Calculating chrM:chr2 ratio from mosdepth coverage summary {input}."
     shell: "(python3 workflow/scripts/calculate_M2_ratio.py {input} > {output}) > {log} 2>&1"
 
 
@@ -29,7 +27,6 @@ rule calculate_gc_coverage:
     log: f"samples/{{sample}}/logs/quality_control/calculate_gc_coverage.{{movie}}.{ref}.log"
     benchmark: f"samples/{{sample}}/benchmarks/quality_control/calculate_gc_coverage.{{movie}}.{ref}.tsv"
     conda: "envs/gc_coverage.yaml"
-    message: "Executing {rule}: Calculating GC coverage distribution from mosdepth coverage by region for {input.mosdepth_regions}."
     shell:
         """
         (bedtools nuc -fi {input.ref} -bed {input.mosdepth_regions} \

--- a/rules/smrtcell_jellyfish.smk
+++ b/rules/smrtcell_jellyfish.smk
@@ -8,7 +8,6 @@ rule samtools_fasta:
     benchmark: "samples/{sample}/benchmarks/samtools/fasta/{movie}.tsv"
     threads: 4
     conda: "envs/samtools.yaml"
-    message: "Executing {rule}: Converting {input} to {output}."
     shell: "(samtools fasta -@ 3 {input} > {output}) > {log} 2>&1"
 
 
@@ -18,7 +17,6 @@ rule seqtk_fastq_to_fasta:
     log: "samples/{sample}/logs/seqtk/seq/{movie}.log"
     benchmark: "samples/{sample}/benchmarks/seqtk/seq/{movie}.tsv"
     conda: "envs/seqtk.yaml"
-    message: "Executing {rule}: Converting {input} to {output}."
     shell: "(seqtk seq -A {input} > {output}) > {log} 2>&1"
 
 
@@ -33,7 +31,6 @@ rule jellyfish_count:
         extra = "--canonical --disk"
     threads: 24
     conda: "envs/jellyfish.yaml"
-    message: "Executing {rule}: Counting {params.kmer_length}mers in {input}."
     shell:
         """
         (jellyfish count {params.extra} \
@@ -52,7 +49,6 @@ rule dump_modimers:
     benchmark: "samples/{sample}/benchmarks/dump_modimers/{movie}.tsv"
     conda: "envs/jellyfish.yaml"
     threads: 2
-    message: "Executing {rule}: Saving modimers for {input}."
     shell:
         """
         (jellyfish dump -c -t {input} \

--- a/rules/smrtcell_mosdepth.smk
+++ b/rules/smrtcell_mosdepth.smk
@@ -15,7 +15,6 @@ rule mosdepth:
         extra = "--no-per-base --use-median"
     threads: 4
     conda: "envs/mosdepth.yaml"
-    message: "Executing {rule}: Calculating coverage of {input.bam} using mosdepth."
     shell:
         """
         (mosdepth \

--- a/rules/smrtcell_pbmm2.smk
+++ b/rules/smrtcell_pbmm2.smk
@@ -18,7 +18,6 @@ rule pbmm2_align_ubam:
         loglevel = "INFO"
     threads: 24
     conda: "envs/pbmm2.yaml"
-    message: "Executing {rule}: Aligning {input.query} to {input.reference} using pbmm2 with --preset {params.preset} {params.extra}."
     shell:
         """
         (pbmm2 align --num-threads {threads} \
@@ -49,7 +48,6 @@ rule pbmm2_align_fastq:
         loglevel = "INFO"
     threads: 24
     conda: "envs/pbmm2.yaml"
-    message: "Executing {rule}: Aligning {input.query} to {input.reference} using pbmm2 with --preset {params.preset} {params.extra}."
     shell:
         """
         (pbmm2 align --num-threads {threads} \

--- a/rules/smrtcell_stats.smk
+++ b/rules/smrtcell_stats.smk
@@ -8,7 +8,6 @@ rule smrtcell_stats_ubam:
     log: "samples/{sample}/logs/smrtcell_stats/{movie}.log"
     benchmark: "samples/{sample}/benchmarks/smrtcell_stats/{movie}.tsv"
     conda: "envs/smrtcell_stats.yaml"
-    message: "Executing {rule}: Read length and quality stats for {input}."
     shell: "(python3 workflow/scripts/extract_read_length_and_qual.py {input} > {output}) > {log} 2>&1"
 
 
@@ -18,7 +17,6 @@ rule smrtcell_stats_fastq:
     log: "samples/{sample}/logs/smrtcell_stats/{movie}.log"
     benchmark: "samples/{sample}/benchmarks/smrtcell_stats/{movie}.tsv"
     conda: "envs/smrtcell_stats.yaml"
-    message: "Executing {rule}: Read length and quality stats for {input}."
     shell: "(python3 workflow/scripts/extract_read_length_and_qual.py {input} > {output}) > {log} 2>&1"
 
 
@@ -27,7 +25,6 @@ rule smrtcell_summary_stats:
     output:
         rlsummary = "samples/{sample}/smrtcell_stats/{movie}.read_length_summary.tsv",
         rqsummary = "samples/{sample}/smrtcell_stats/{movie}.read_quality_summary.tsv"
-    message: "Executing {rule}: Summarize read length and quality stats for {wildcards.movie}."
     log: "samples/{sample}/logs/smrtcell_stats/{movie}.summary.log"
     benchmark: "samples/{sample}/benchmarks/smrtcell_stats/{movie}.summary.tsv"
     conda: "envs/smrtcell_stats.yaml"


### PR DESCRIPTION
By removing these message directives, snakemake will automatically print a short summary for each rule which includes the wildcards and resources.