### PR TITLE
provide 4 threads to whatshap haplotag

### DIFF
--- a/rules/sample_whatshap.smk
+++ b/rules/sample_whatshap.smk
@@ -79,10 +79,12 @@ rule whatshap_haplotag:
     log: f"samples/{sample}/logs/whatshap/haplotag/{sample}.{ref}.{{movie}}.log"
     benchmark: f"samples/{sample}/benchmarks/whatshap/haplotag/{sample}.{ref}.{{movie}}.tsv"
     params: "--tag-supplementary"
+	threads: 4
     conda: "envs/whatshap.yaml"
     shell:
         """
         (whatshap haplotag {params} \
+            --output-threads {threads} \
             --output {output} \
             --reference {input.reference} \
             {input.vcf} {input.bam}) > {log} 2>&1


### PR DESCRIPTION
Takes advantage of new `whatshap haplotag --output-threads N` option.  Should lead to a significant speed-up.

Closes #105.