### PR TITLE
bugfix/leading_zero_sample_names

### DIFF
--- a/process_cohort.local.sh
+++ b/process_cohort.local.sh
@@ -21,7 +21,7 @@ mkdir -p logs
 
 # execute snakemake
 snakemake \
-    --config cohort=${COHORT} \
+    --config "cohort='$COHORT'" \
     --nolock \
     --profile workflow/profiles/local \
     --snakefile workflow/process_cohort.smk \

--- a/process_cohort.lsf.sh
+++ b/process_cohort.lsf.sh
@@ -24,7 +24,7 @@ source workflow/variables.env
 
 # execute snakemake
 snakemake \
-    --config cohort=${COHORT} \
+    --config "cohort='$COHORT'" \
     --nolock \
     --profile workflow/profiles/lsf \
     --snakefile workflow/process_cohort.smk

--- a/process_cohort.sge.sh
+++ b/process_cohort.sge.sh
@@ -27,7 +27,7 @@ source workflow/variables.env
 
 # execute snakemake
 snakemake \
-    --config cohort=${COHORT} \
+    --config "cohort='$COHORT'" \
     --nolock \
     --profile workflow/profiles/sge \
     --snakefile workflow/process_cohort.smk

--- a/process_cohort.slurm.sh
+++ b/process_cohort.slurm.sh
@@ -24,7 +24,7 @@ source workflow/variables.env
 
 # execute snakemake
 snakemake \
-    --config cohort=${COHORT} \
+    --config "cohort='$COHORT'" \
     --nolock \
     --profile workflow/profiles/slurm \
     --snakefile workflow/process_cohort.smk

--- a/process_sample.local.sh
+++ b/process_sample.local.sh
@@ -20,7 +20,7 @@ mkdir -p logs
 
 # execute snakemake
 snakemake \
-    --config sample=${SAMPLE} \
+    --config "sample='$SAMPLE'" \
     --nolock \
     --profile workflow/profiles/local \
     --snakefile workflow/process_sample.smk \

--- a/process_sample.lsf.sh
+++ b/process_sample.lsf.sh
@@ -23,7 +23,7 @@ source workflow/variables.env
 
 # execute snakemake
 snakemake \
-    --config sample=${SAMPLE} \
+    --config "sample='$SAMPLE'" \
     --nolock \
     --profile workflow/profiles/lsf \
     --snakefile workflow/process_sample.smk

--- a/process_sample.sge.sh
+++ b/process_sample.sge.sh
@@ -26,7 +26,7 @@ source workflow/variables.env
 
 # execute snakemake
 snakemake \
-    --config sample=${SAMPLE} \
+    --config "sample='$SAMPLE'" \
     --nolock \
     --profile workflow/profiles/sge \
     --snakefile workflow/process_sample.smk

--- a/process_sample.slurm.sh
+++ b/process_sample.slurm.sh
@@ -23,7 +23,7 @@ source workflow/variables.env
 
 # execute snakemake
 snakemake \
-    --config sample=${SAMPLE} \
+    --config "sample='$SAMPLE'" \
     --nolock \
     --profile workflow/profiles/slurm \
     --snakefile workflow/process_sample.smk


### PR DESCRIPTION
This should allow sample and cohort names with leading zeros. Not tested end-to-end, only at interface between bash script and snakemake variables