### PR TITLE
Bugfix: Allow fully numeric samples naming

### DIFF
--- a/process_cohort.smk
+++ b/process_cohort.smk
@@ -24,7 +24,7 @@ def get_samples(cohortyaml=config['cohort_yaml'], cohort_id=config['cohort']):
         if affectedstatus in c:
             for individual in range(len(c[affectedstatus])):
                 samples.append(c[affectedstatus][individual]['id'])
-    return samples
+    return [str(x) for x in samples]
 
 def get_trios(cohortyaml=config['cohort_yaml'], cohort_id=config['cohort']):
     """Find all trios associated with cohort."""

--- a/process_sample.smk
+++ b/process_sample.smk
@@ -14,7 +14,7 @@ def check_for_ml_tag(bams):
     for bam in bams:
         with pysam.AlignmentFile(bam, "rb", check_sq=False) as bamfile:
             for record in bamfile:
-                if record.has_tag("Ml") or record.has_tag("ML"):
+                if record.has_tag("Ml"):
                     # BAM has basemod tag
                     return True
     # only reaches this stage if no BAMs contain basemod tag

--- a/process_sample.smk
+++ b/process_sample.smk
@@ -14,7 +14,7 @@ def check_for_ml_tag(bams):
     for bam in bams:
         with pysam.AlignmentFile(bam, "rb", check_sq=False) as bamfile:
             for record in bamfile:
-                if record.has_tag("Ml"):
+                if record.has_tag("Ml") or record.has_tag("ML"):
                     # BAM has basemod tag
                     return True
     # only reaches this stage if no BAMs contain basemod tag


### PR DESCRIPTION
Line 99 `(match.group('sample') in samples)` will return `False` for fully numeric sample naming, because `get_samples` is a numeric list, while `re.match` output is a string. Modification here forces `get_samples` to return samples in strings.