### PR TITLE
Bug: Syntax issue

### DIFF
--- a/scripts/gff_translate.py
+++ b/scripts/gff_translate.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Translate chromosomes in Ensembl GFF3, ignore chromosomes missing from lookup."""
 
-lookup_table = {x: f'chr{x}' for x in list(range(1, 23)).extend('X', 'Y')}
-lookup_table.extend({'MT': 'chrM'})
+lookup_table = {f'{x}': f'chr{x}' for x in [*range(1,23), 'X', 'Y']}
+lookup_table['MT'] = 'chrM'
 
 with open('/dev/stdin', 'r') as gff:
     for row in gff:


### PR DESCRIPTION
The `extend` syntax did not work on Python 3.7.13 (It will return empty `NoneType` at line 4 for `lookup_table`). In addition, the key for `lookup_table` was numerical, so the comparison will fail as `fields` read as strings.