### PR TITLE
Allow singularity to use gpu in local profile

### DIFF
--- a/profiles/local/config.yaml
+++ b/profiles/local/config.yaml
@@ -7,5 +7,6 @@ use-conda: true
 conda-frontend: mamba
 latency-wait: 120
 use-singularity: true
-default-resources: 
+singularity-args: '--nv '
+default-resources:
   - tmpdir=system_tmpdir


### PR DESCRIPTION
`singularity-args` was missing from local profile.