### PR TITLE
Add trgt to process_sample

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ sample_targets:
   - kmers  # req: kmers in config['smrtcells_targets']
   - assembly
   - tandem-genotypes  # req: whatshap
+  - trgt  # req: whatshap
   - 5mc_cpg_pileup # req: whatshap; also requires uBAM input with basemods
 
 cohort_targets:

--- a/process_sample.smk
+++ b/process_sample.smk
@@ -100,6 +100,13 @@ if 'tandem-genotypes' in config['sample_targets']:
     targets.extend([f"samples/{sample}/tandem-genotypes/{sample}.tandem-genotypes.{suffix}"
                     for suffix in ['txt', 'pdf', 'absolute.txt', 'dropouts.txt']])
 
+# genotype tandem repeats with TRGT
+include: 'rules/sample_trgt.smk'
+if 'trgt' in config['sample_targets']:
+    # trgt VCF and BAM
+    targets.extend([f"samples/{sample}/trgt/{sample}.{ref}.trgt.{suffix}"
+                    for suffix in ['dropouts.txt', 'spanning.bam', 'vcf.gz']])
+
 # calculate coverage of haplotagged sample aBAM with mosdepth
 include: 'rules/sample_mosdepth.smk'
 include: 'rules/sample_gc_coverage.smk'

--- a/reference.yaml
+++ b/reference.yaml
@@ -13,6 +13,7 @@ ref:
   tg_list_url: 'https://github.com/mcfrith/tandem-genotypes/raw/master/hg38-disease-tr.txt'
   tg_list: 'resources/tandem-genotypes/hg38-disease-tr.txt'
   tg_bed: 'resources/tandem-genotypes/hg38-disease-tr.slop.bed'
+  trgt_bed: 'reference/human_GRCh38_no_alt_analysis_set.trgt.bed'
   gnomad_gnotate: 'resources/slivar/gnomad.hg38.v3.custom.zip'
   hprc_dv_gnotate: 'resources/slivar/hprc.deepvariant.glnexus.hg38.v1.zip'
   eee_vcf: 'resources/eee/EEE_SV-Pop_1.ALL.sites.20181204.vcf.gz'

--- a/rules/envs/trgt.yaml
+++ b/rules/envs/trgt.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - trgt=0.3.3
+  - trgt=0.3.4

--- a/rules/envs/trgt.yaml
+++ b/rules/envs/trgt.yaml
@@ -1,0 +1,6 @@
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - trgt=0.3.3

--- a/rules/sample_trgt.smk
+++ b/rules/sample_trgt.smk
@@ -1,0 +1,40 @@
+ruleorder: trgt_genotype > bgzip_vcf
+
+
+rule trgt_genotype:
+    input:
+        reference = config['ref']['fasta'],
+        bam = f"samples/{sample}/whatshap/{sample}.{ref}.deepvariant.haplotagged.bam",
+        bai = f"samples/{sample}/whatshap/{sample}.{ref}.deepvariant.haplotagged.bam.bai",
+        bed = config['ref']['trgt_bed'],
+    output:
+        vcf = f"samples/{sample}/trgt/{sample}.{ref}.trgt.vcf.gz",
+        bam = f"samples/{sample}/trgt/{sample}.{ref}.trgt.spanning.bam",
+    log: f"samples/{sample}/logs/trgt/genotype.log"
+    benchmark: f"samples/{sample}/benchmarks/trgt/genotype.tsv"
+    conda: "envs/trgt.yaml"
+    params:
+        prefix = f"samples/{sample}/trgt/{sample}.{ref}.trgt"
+    threads: 32
+    message: "Executing {rule}: Genotyping tandem repeat regions from {input.bed} in {input.bam}."
+    shell:
+        """
+        (trgt --threads {threads} \
+            --genome {input.reference} \
+            --repeats {input.bed} \
+            --reads {input.bam} \
+            --output-prefix {params.prefix}) > {log} 2>&1
+        """
+
+
+rule trgt_coverage_dropouts:
+    input:
+        bam = f"samples/{sample}/whatshap/{sample}.{ref}.deepvariant.haplotagged.bam",
+        bai = f"samples/{sample}/whatshap/{sample}.{ref}.deepvariant.haplotagged.bam.bai",
+        bed = config['ref']['trgt_bed']
+    output: f"samples/{sample}/trgt/{sample}.{ref}.trgt.dropouts.txt"
+    log: f"samples/{sample}/logs/trgt/{sample}.dropouts.log"
+    benchmark: f"samples/{sample}/benchmarks/trgt/{sample}.dropouts.tsv"
+    conda: "envs/tandem-genotypes.yaml"
+    message: "Executing {rule}: Identify coverage dropouts in {input.bed} regions in {input.bam}."
+    shell: "(python3 workflow/scripts/check_trgt_coverage.py {input.bed} {input.bam} > {output}) > {log} 2>&1"

--- a/scripts/check_trgt_coverage.py
+++ b/scripts/check_trgt_coverage.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Identify tandem repeat regions in the genome that might have missed
+variants due to coverage dropouts perhaps induced by repeat expansions.
+"""
+
+
+__version__ = "0.1.0"
+
+
+import argparse
+import collections
+import pysam
+
+
+class TandemRepeatRegion:
+    def __init__(self, chrom, chromStart, chromEnd, label):
+        self.chrom = chrom
+        self.chromStart = int(chromStart)
+        self.chromEnd = int(chromEnd)
+        self.label = label
+
+
+def main(args):
+    # Read the tandem repeat regions of interest
+    tandemRepeats = list()
+    f = open(args.trbed)
+    for l in f:
+        cols = l.rstrip().split("\t")
+        tandemRepeats.append(TandemRepeatRegion(cols[0], cols[1], cols[2], cols[3]))
+    f.close()
+
+
+    bam = pysam.AlignmentFile(args.bam, "rb")
+    # Infer sample sex from the chrX:chr2 ratio (MALE if chrX:chr2 < 0.7).
+    # The sex helps with interpreting coverage for chrX variants.
+    chromReadsPerMb = dict()
+    chromLens = dict()
+    for l in pysam.idxstats(args.bam).rstrip("\n").split("\n"):
+        chrom,chromLen,mappedReads,unmappedReads = l.split("\t")
+        if float(chromLen)>1:
+            chromReadsPerMb[chrom] = 1e6*float(mappedReads)/float(chromLen)
+            chromLens[chrom] = int(chromLen)
+    chrX = chromReadsPerMb.get("chrX", chromReadsPerMb.get("X"))
+    chrY = chromReadsPerMb.get("chrY", chromReadsPerMb.get("Y"))
+    chr2 = chromReadsPerMb.get("chr2", chromReadsPerMb.get("2"))
+    if chrX is not None and chrY is not None and chr2 is not None:
+        sex = "MALE" if chrX/chr2 < 0.7 else "FEMALE"
+    else:
+        sex = "UNKNOWN"
+
+
+    # Evaluate the spanning read coverage for each region,
+    # considering reads by phase (HP=1, HP=2, unphased).
+    PAD = 1000
+    for tandemRepeat in tandemRepeats:
+        hp1Spanners,hp2Spanners,unphasedSpanners = [],[],[]
+        readStarts = collections.defaultdict(int)     # map from read name to lowest start position in the region
+        readEnds = collections.defaultdict(int)       # map from read name to highest end position in the region
+        readHaplotypes = collections.defaultdict(set) # map from read name to (phase set, haplotype) tags
+
+        # Fetch reads +/- PAD from the region of interest.
+        # Record the lowest start and highest end postion of alignments for the read.
+        alignments = bam.fetch(tandemRepeat.chrom, max(0,tandemRepeat.chromStart-PAD), min(tandemRepeat.chromEnd+PAD, chromLens[tandemRepeat.chrom]))
+        for al in alignments:
+            if al.query_name not in readStarts:
+                readStarts[al.query_name] = al.reference_start
+                readEnds[al.query_name] = al.reference_end
+            readStarts[al.query_name] = min(readStarts[al.query_name], al.reference_start)
+            readEnds[al.query_name] = min(readEnds[al.query_name], al.reference_end)
+            if al.has_tag("HP") and al.has_tag("PS"):
+                readHaplotypes[al.query_name].add((al.get_tag("PS"),al.get_tag("HP")))
+
+        # Identify reads that span the region of interest.
+        for query_name in readStarts:
+            if readStarts[query_name] <= tandemRepeat.chromStart and readEnds[query_name] >= tandemRepeat.chromEnd:
+                if len(readHaplotypes[query_name]) == 1:
+                    if list(readHaplotypes[query_name])[0][1] == 1:
+                        hp1Spanners.append(query_name)
+                    else:
+                        hp2Spanners.append(query_name)
+                else:
+                    unphasedSpanners.append(query_name)
+        phasedSpanners = hp1Spanners + hp2Spanners
+        totalSpanners = phasedSpanners + unphasedSpanners
+
+        # Consider a region as a full dropout if it has fewer than `coverage` spanning reads.
+        if len(totalSpanners) < args.coverage:
+            print("%s\t%d\t%d\t%s\tFullDropout" % (tandemRepeat.chrom, tandemRepeat.chromStart, tandemRepeat.chromEnd, tandemRepeat.label))
+        # If the region is phased (i.e. spanned by fewer than `coverage` unphased reads) then evaluate haplotype-specific coverage.
+        elif len(unphasedSpanners) < args.coverage:
+            # Ignore chrX variants in a male.
+            if len(phasedSpanners) and not (sex == "MALE" and tandemRepeat.chrom in ("X","chrX")):
+                if len(hp1Spanners) < args.coverage or len(hp2Spanners) < args.coverage:
+                    print("%s\t%d\t%d\t%s\tHaplotypeDropout" % (tandemRepeat.chrom, tandemRepeat.chromStart, tandemRepeat.chromEnd, tandemRepeat.label))
+
+    bam.close()
+
+
+if __name__ == "__main__":
+    """ This is executed when run from the command line """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trbed", help="Regions of interest, BED4+ (chrom<TAB>chromStart<TAB>chromEnd<TAB>motif<TAB>label<TAB>region)")
+    parser.add_argument("bam", help="Alignments, BAM")
+    parser.add_argument("--coverage", type=int, default=2, help="Minimum coverage to consider a region as covered [default: %(default)s]")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s (version {version})".format(version=__version__))
+
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
- trgt runs on merged, haplotagged BAM using regions in BED file in `reference/` dir
- generates vcf.gz and spanning.bam
- uses trgt v0.3.4
- also generates a text file indicating regions in bed file that are not covered well in input BAM