### PR TITLE
Add account resource to lsf profile

### DIFF
--- a/Tutorial.md
+++ b/Tutorial.md
@@ -257,17 +257,18 @@ The following configuration files should not be modified unless you're confident
 We have provided sample submission scripts for three different schedulers (SLURM, SGE, LSF) as well as a local execution option. The following files **may need to be edited** based on the specifics of your HPC cluster. Additional flags may be necessary for job submission and you may need to talk to your HPC administrator if the example scripts aren’t working.
 
 - `process_smrtcells.(slurm|sge|lsf|local).sh`
-- `process_sample.(slurm|sge|lsf|local).sh`]
+- `process_sample.(slurm|sge|lsf|local).sh`
 - `process_cohort.(slurm|sge|lsf|local).sh`
 - `profiles/(slurm|sge|lsf|local)/config.yaml` # snakemake configuration [profiles](https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles)
 - `rules/sample_deepvariant.smk` # GPU and singularity constraints specified within rules
-- `variables.env` # environment variables such as TMPDIR and cluster partition
+- `variables.env` # environment variables such as TMPDIR, cluster partition, and cluster account
 
 > **WARNING**:
 >
 > - We recommend at least 80 cores and 1TB RAM for local execution.  Local execution will use all available cores.
 > - Job scripts and configuration for SGE and LSF schedulers are included as a courtesy, but are not regularly tested or maintained.
 > - Unintential or misinformed changes to these files may prevent the workflows from running properly.
+> - If a cluster "account" is required for proper billing, change the account value from `100humans` in `variables.env` and in the relevant `*.(slurm|sge|lsf|local).sh` files.
 
 [Back to top](#TOP)
 

--- a/process_cohort.lsf.sh
+++ b/process_cohort.lsf.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#BSUB -P 100humans
 #BSUB -cwd
 #BSUB -L /bin/bash
 #BSUB -q default

--- a/process_sample.lsf.sh
+++ b/process_sample.lsf.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#BSUB -P 100humans
 #BSUB -cwd
 #BSUB -L /bin/bash
 #BSUB -q default

--- a/process_smrtcells.lsf.sh
+++ b/process_smrtcells.lsf.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#BSUB -P 100humans
 #BSUB -cwd
 #BSUB -L /bin/bash
 #BSUB -q default

--- a/profiles/lsf/config.yaml
+++ b/profiles/lsf/config.yaml
@@ -12,12 +12,14 @@ latency-wait: 120
 use-singularity: true
 singularity-args: '--nv '
 cluster: bsub -cwd 
+              -P {resources.account}
               -q {resources.partition}
               -n {threads}
               -M {resources.mem_mb}
               -o {resources.out}
               -e {resources.err} {resources.extra}
-default-resources: 
+default-resources:
+  - account='$ACCOUNT'
   - partition='$PARTITION'
   - tmpdir=system_tmpdir
   - threads=1


### PR DESCRIPTION
Some installations of bsub require a project for billing or time accounting purposes, similar to [`sbatch --account`](https://github.com/PacificBiosciences/pb-human-wgs-workflow-snakemake/blob/1feaed908a3c201ee9d8798f03b8e4253a9a51e3/profiles/slurm/config.yaml#L14).  Stealing the syntax we used for the slurm profile here.

- added `account=$ACCOUNT` to the default resources for lsf
- added `-P {resources.account}` to the cluster submission template for lsf

To use, set the [account variable in variables.env](https://github.com/PacificBiosciences/pb-human-wgs-workflow-snakemake/blob/1feaed908a3c201ee9d8798f03b8e4253a9a51e3/variables.env#L3).