### PR TITLE
Update to DeepVariant v1.5.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,8 +36,8 @@ N_SHARDS: 256
 # additional configuration specific to job schedulers can be found variables.env
 # change to True if you don't have GPUs available
 cpu_only: False
-deepvariant_cpu_version: '1.4.0'
-deepvariant_gpu_version: '1.4.0-gpu'
+deepvariant_cpu_version: '1.5.0'
+deepvariant_gpu_version: '1.5.0-gpu'
 
 # glnexus
 GLNEXUS_VERSION: 'v1.4.1'


### PR DESCRIPTION
- new model trained on Sequel II + Revio

Hold for official DeepVariant v1.5.0 release