### PR TITLE
Update hifiasm

### DIFF
--- a/rules/envs/hifiasm.yaml
+++ b/rules/envs/hifiasm.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - hifiasm=0.15
+  - hifiasm=0.18.9


### PR DESCRIPTION
- older hifiasm versions _built by conda_ are slower than those same versions built outside of conda https://github.com/chhylp123/hifiasm/issues/392
- this is a problem with the conda build process
- fixed recently https://github.com/chhylp123/hifiasm/issues/392