### PR TITLE
fix: missing parenthesis

### DIFF
--- a/process_sample.smk
+++ b/process_sample.smk
@@ -15,7 +15,7 @@ def check_header_for_basemod_tools(bams):
     for bam in bams:
         with pysam.AlignmentFile(bam, "rb", check_sq=False) as bamfile:
             # BAMs processed with basemod tools will have header PG ID
-            if {_['ID'] for _ in bamfile.header.as_dict()['PG']} & basemod_tools):
+            if ({_['ID'] for _ in bamfile.header.as_dict()['PG']} & basemod_tools):
                 return True
     return False
 


### PR DESCRIPTION
I got a weird error when running `process_sample.smk`:
```
Token Error: EOF in multi-line statement (158,0)
```
and it turns out to be a syntax error.